### PR TITLE
Add comprehensive Wars dashboard page with statistics and configuration

### DIFF
--- a/app/[locale]/dashboard/[guildId]/wars/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/wars/page.tsx
@@ -1,0 +1,857 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Target,
+  Calendar,
+  Trophy,
+  Swords,
+  Users,
+  Bell,
+  Settings,
+  Shield,
+  Filter,
+  Download,
+  TrendingUp,
+  Star
+} from "lucide-react";
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { darkTheme, clashKingColors } from "@/lib/theme";
+
+// Mock data for war statistics
+const warStatsData = [
+  { name: "Mon", wins: 4, losses: 1, draws: 0 },
+  { name: "Tue", wins: 3, losses: 2, draws: 1 },
+  { name: "Wed", wins: 5, losses: 0, draws: 0 },
+  { name: "Thu", wins: 2, losses: 3, draws: 0 },
+  { name: "Fri", wins: 4, losses: 1, draws: 1 },
+  { name: "Sat", wins: 6, losses: 0, draws: 0 },
+  { name: "Sun", wins: 3, losses: 2, draws: 0 },
+];
+
+const attackSuccessData = [
+  { th: "TH16", success: 85, failed: 15 },
+  { th: "TH15", success: 78, failed: 22 },
+  { th: "TH14", success: 82, failed: 18 },
+  { th: "TH13", success: 90, failed: 10 },
+  { th: "TH12", success: 88, failed: 12 },
+];
+
+const warTypeDistribution = [
+  { name: "CWL", value: 45, color: clashKingColors.primary },
+  { name: "Random", value: 30, color: "#FAA81A" },
+  { name: "Friendly", value: 25, color: "#3BA55D" },
+];
+
+const topPerformers = [
+  { name: "Player1", attacks: 156, stars: 450, destruction: 92.5 },
+  { name: "Player2", attacks: 148, stars: 432, destruction: 90.2 },
+  { name: "Player3", attacks: 142, stars: 418, destruction: 89.7 },
+  { name: "Player4", attacks: 139, stars: 410, destruction: 88.9 },
+  { name: "Player5", attacks: 135, stars: 398, destruction: 87.5 },
+];
+
+const mockClans = [
+  { tag: "#CLAN123", name: "Elite Warriors" },
+  { tag: "#CLAN456", name: "Training Ground" },
+  { tag: "#CLAN789", name: "War Masters" },
+];
+
+export default function WarsPage() {
+  const [filters, setFilters] = useState({
+    clan: "all",
+    user: "",
+    townHall: "all",
+    startDate: "",
+    endDate: "",
+  });
+
+  const [reminders, setReminders] = useState({
+    randomWar: {
+      enabled: true,
+      time: "6",
+      role: "@WarTeam",
+    },
+    friendlyWar: {
+      enabled: true,
+      time: "3",
+      role: "@Members",
+    },
+    cwl: {
+      enabled: true,
+      time: "12",
+      role: "@CWLRoster",
+    },
+  });
+
+  const [warLogs, setWarLogs] = useState({
+    enabled: true,
+    channel: "#war-logs",
+    includeAttacks: true,
+    includeDefenses: true,
+    pingOnLoss: true,
+    celebrateWin: true,
+  });
+
+  const handleFilterChange = (key: string, value: string) => {
+    setFilters({ ...filters, [key]: value });
+  };
+
+  return (
+    <div className="p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <div className="flex items-center gap-3">
+              <div className="p-3 rounded-lg bg-gradient-to-br from-red-500/20 to-red-600/20 border border-red-500/30">
+                <Swords className="h-8 w-8 text-red-500" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-white">War Management</h1>
+                <p className="text-gray-600 dark:text-gray-400 mt-1">
+                  Track statistics, configure reminders, and manage war logs
+                </p>
+              </div>
+            </div>
+          </div>
+          <Button className="bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800">
+            <Download className="mr-2 h-4 w-4" />
+            Export Data
+          </Button>
+        </div>
+
+        <Tabs defaultValue="statistics" className="space-y-6">
+          <TabsList className="grid w-full grid-cols-3 lg:w-[600px]">
+            <TabsTrigger value="statistics">
+              <Trophy className="mr-2 h-4 w-4" />
+              Statistics
+            </TabsTrigger>
+            <TabsTrigger value="reminders">
+              <Bell className="mr-2 h-4 w-4" />
+              Reminders
+            </TabsTrigger>
+            <TabsTrigger value="logs">
+              <Settings className="mr-2 h-4 w-4" />
+              War Logs
+            </TabsTrigger>
+          </TabsList>
+
+          {/* WAR STATISTICS TAB */}
+          <TabsContent value="statistics" className="space-y-6">
+            {/* Filters Card */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <Filter className="h-5 w-5" />
+                      Filters
+                    </CardTitle>
+                    <CardDescription>Filter war statistics by various criteria</CardDescription>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => setFilters({
+                    clan: "all",
+                    user: "",
+                    townHall: "all",
+                    startDate: "",
+                    endDate: "",
+                  })}>
+                    Reset Filters
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-5">
+                  <div className="space-y-2">
+                    <Label htmlFor="clan-filter">Clan</Label>
+                    <Select value={filters.clan} onValueChange={(value) => handleFilterChange("clan", value)}>
+                      <SelectTrigger id="clan-filter">
+                        <SelectValue placeholder="Select clan" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All Clans</SelectItem>
+                        {mockClans.map((clan) => (
+                          <SelectItem key={clan.tag} value={clan.tag}>
+                            {clan.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="user-filter">User</Label>
+                    <Input
+                      id="user-filter"
+                      placeholder="Search user..."
+                      value={filters.user}
+                      onChange={(e) => handleFilterChange("user", e.target.value)}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="th-filter">Town Hall</Label>
+                    <Select value={filters.townHall} onValueChange={(value) => handleFilterChange("townHall", value)}>
+                      <SelectTrigger id="th-filter">
+                        <SelectValue placeholder="Select TH" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All TH Levels</SelectItem>
+                        {[16, 15, 14, 13, 12, 11, 10, 9, 8].map((th) => (
+                          <SelectItem key={th} value={th.toString()}>
+                            TH {th}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="start-date">Start Date</Label>
+                    <Input
+                      id="start-date"
+                      type="date"
+                      value={filters.startDate}
+                      onChange={(e) => handleFilterChange("startDate", e.target.value)}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="end-date">End Date</Label>
+                    <Input
+                      id="end-date"
+                      type="date"
+                      value={filters.endDate}
+                      onChange={(e) => handleFilterChange("endDate", e.target.value)}
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Summary Stats */}
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+              <Card className="border-green-500/30 bg-green-500/5">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">Total Wins</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="text-3xl font-bold text-green-500">127</div>
+                    <Trophy className="h-8 w-8 text-green-500/50" />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    <span className="text-green-500">+12%</span> from last month
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-red-500/30 bg-red-500/5">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">Total Losses</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="text-3xl font-bold text-red-500">34</div>
+                    <Shield className="h-8 w-8 text-red-500/50" />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    <span className="text-red-500">-8%</span> from last month
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-yellow-500/30 bg-yellow-500/5">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">Win Rate</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="text-3xl font-bold text-yellow-500">78.9%</div>
+                    <TrendingUp className="h-8 w-8 text-yellow-500/50" />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    <span className="text-green-500">+3.2%</span> improvement
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-blue-500/30 bg-blue-500/5">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">Avg Stars</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="text-3xl font-bold text-blue-500">2.7</div>
+                    <Star className="h-8 w-8 text-blue-500/50" />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Per attack average
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Charts Row 1 */}
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>War Performance (Last 7 Days)</CardTitle>
+                  <CardDescription>Daily wins, losses, and draws</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={warStatsData}>
+                      <CartesianGrid strokeDasharray="3 3" stroke={darkTheme.border.primary} />
+                      <XAxis dataKey="name" stroke={darkTheme.text.secondary} />
+                      <YAxis stroke={darkTheme.text.secondary} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: darkTheme.background.elevated,
+                          border: `1px solid ${darkTheme.border.primary}`,
+                          borderRadius: '8px',
+                        }}
+                      />
+                      <Legend />
+                      <Bar dataKey="wins" fill="#3BA55D" name="Wins" />
+                      <Bar dataKey="losses" fill="#ED4245" name="Losses" />
+                      <Bar dataKey="draws" fill="#FAA81A" name="Draws" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Attack Success Rate by Town Hall</CardTitle>
+                  <CardDescription>Success vs failed attacks per TH level</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={attackSuccessData} layout="vertical">
+                      <CartesianGrid strokeDasharray="3 3" stroke={darkTheme.border.primary} />
+                      <XAxis type="number" stroke={darkTheme.text.secondary} />
+                      <YAxis dataKey="th" type="category" stroke={darkTheme.text.secondary} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: darkTheme.background.elevated,
+                          border: `1px solid ${darkTheme.border.primary}`,
+                          borderRadius: '8px',
+                        }}
+                      />
+                      <Legend />
+                      <Bar dataKey="success" fill="#3BA55D" name="Success %" stackId="a" />
+                      <Bar dataKey="failed" fill="#ED4245" name="Failed %" stackId="a" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Charts Row 2 */}
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>War Type Distribution</CardTitle>
+                  <CardDescription>Breakdown of war types in the last 30 days</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={300}>
+                    <PieChart>
+                      <Pie
+                        data={warTypeDistribution}
+                        cx="50%"
+                        cy="50%"
+                        labelLine={false}
+                        label={({ name, value }) => `${name}: ${value}%`}
+                        outerRadius={100}
+                        fill="#8884d8"
+                        dataKey="value"
+                      >
+                        {warTypeDistribution.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={entry.color} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: darkTheme.background.elevated,
+                          border: `1px solid ${darkTheme.border.primary}`,
+                          borderRadius: '8px',
+                        }}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Top Performers</CardTitle>
+                  <CardDescription>Best warriors in the last 30 days</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    {topPerformers.map((player, index) => (
+                      <div key={player.name} className="flex items-center gap-4">
+                        <div className={`w-8 h-8 rounded-full flex items-center justify-center font-bold ${
+                          index === 0 ? 'bg-yellow-500/20 text-yellow-500' :
+                          index === 1 ? 'bg-gray-400/20 text-gray-400' :
+                          index === 2 ? 'bg-orange-500/20 text-orange-500' :
+                          'bg-gray-600/20 text-gray-500'
+                        }`}>
+                          {index + 1}
+                        </div>
+                        <div className="flex-1">
+                          <div className="font-medium text-white">{player.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {player.attacks} attacks • {player.stars} stars
+                          </div>
+                        </div>
+                        <Badge variant="secondary" className="bg-green-500/20 text-green-500 border-green-500/30">
+                          {player.destruction}%
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+
+          {/* WAR REMINDERS TAB */}
+          <TabsContent value="reminders" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Bell className="h-5 w-5 text-red-500" />
+                  <div>
+                    <CardTitle>War Reminders Configuration</CardTitle>
+                    <CardDescription>
+                      Set up automatic reminders for different war types
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-8">
+                {/* Random War Reminders */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-semibold text-lg text-white flex items-center gap-2">
+                        <Target className="h-5 w-5 text-red-500" />
+                        Random War
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        Reminders for regular clan wars
+                      </p>
+                    </div>
+                    <Switch
+                      checked={reminders.randomWar.enabled}
+                      onCheckedChange={(checked) =>
+                        setReminders({
+                          ...reminders,
+                          randomWar: { ...reminders.randomWar, enabled: checked },
+                        })
+                      }
+                    />
+                  </div>
+
+                  {reminders.randomWar.enabled && (
+                    <div className="ml-7 space-y-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="random-time">Reminder Time (hours before)</Label>
+                          <Input
+                            id="random-time"
+                            type="number"
+                            min="1"
+                            max="24"
+                            value={reminders.randomWar.time}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                randomWar: { ...reminders.randomWar, time: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="random-role">Ping Role</Label>
+                          <Input
+                            id="random-role"
+                            placeholder="@WarTeam"
+                            value={reminders.randomWar.role}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                randomWar: { ...reminders.randomWar, role: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                {/* Friendly War Reminders */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-semibold text-lg text-white flex items-center gap-2">
+                        <Users className="h-5 w-5 text-green-500" />
+                        Friendly War
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        Reminders for friendly wars
+                      </p>
+                    </div>
+                    <Switch
+                      checked={reminders.friendlyWar.enabled}
+                      onCheckedChange={(checked) =>
+                        setReminders({
+                          ...reminders,
+                          friendlyWar: { ...reminders.friendlyWar, enabled: checked },
+                        })
+                      }
+                    />
+                  </div>
+
+                  {reminders.friendlyWar.enabled && (
+                    <div className="ml-7 space-y-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="friendly-time">Reminder Time (hours before)</Label>
+                          <Input
+                            id="friendly-time"
+                            type="number"
+                            min="1"
+                            max="24"
+                            value={reminders.friendlyWar.time}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                friendlyWar: { ...reminders.friendlyWar, time: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="friendly-role">Ping Role</Label>
+                          <Input
+                            id="friendly-role"
+                            placeholder="@Members"
+                            value={reminders.friendlyWar.role}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                friendlyWar: { ...reminders.friendlyWar, role: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                {/* CWL Reminders */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-semibold text-lg text-white flex items-center gap-2">
+                        <Trophy className="h-5 w-5 text-yellow-500" />
+                        Clan War League (CWL)
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        Reminders for Clan War League battles
+                      </p>
+                    </div>
+                    <Switch
+                      checked={reminders.cwl.enabled}
+                      onCheckedChange={(checked) =>
+                        setReminders({
+                          ...reminders,
+                          cwl: { ...reminders.cwl, enabled: checked },
+                        })
+                      }
+                    />
+                  </div>
+
+                  {reminders.cwl.enabled && (
+                    <div className="ml-7 space-y-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="cwl-time">Reminder Time (hours before)</Label>
+                          <Input
+                            id="cwl-time"
+                            type="number"
+                            min="1"
+                            max="24"
+                            value={reminders.cwl.time}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                cwl: { ...reminders.cwl, time: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="cwl-role">Ping Role</Label>
+                          <Input
+                            id="cwl-role"
+                            placeholder="@CWLRoster"
+                            value={reminders.cwl.role}
+                            onChange={(e) =>
+                              setReminders({
+                                ...reminders,
+                                cwl: { ...reminders.cwl, role: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Save Button */}
+            <div className="flex justify-end gap-4">
+              <Button variant="outline">Reset to Default</Button>
+              <Button className="bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800">
+                Save Reminder Settings
+              </Button>
+            </div>
+          </TabsContent>
+
+          {/* WAR LOGS TAB */}
+          <TabsContent value="logs" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Settings className="h-5 w-5 text-red-500" />
+                  <div>
+                    <CardTitle>War Logs Configuration</CardTitle>
+                    <CardDescription>
+                      Configure how war logs are displayed in your Discord server
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                {/* Main Toggle */}
+                <div className="flex items-center justify-between p-4 rounded-lg bg-red-500/5 border border-red-500/20">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="logs-enabled" className="text-base font-semibold">Enable War Logs</Label>
+                    <p className="text-sm text-muted-foreground">
+                      Automatically post war results and stats to a designated channel
+                    </p>
+                  </div>
+                  <Switch
+                    id="logs-enabled"
+                    checked={warLogs.enabled}
+                    onCheckedChange={(checked) =>
+                      setWarLogs({ ...warLogs, enabled: checked })
+                    }
+                  />
+                </div>
+
+                {warLogs.enabled && (
+                  <>
+                    <Separator />
+
+                    {/* Channel Selection */}
+                    <div className="space-y-2">
+                      <Label htmlFor="log-channel">War Logs Channel</Label>
+                      <Select value={warLogs.channel} onValueChange={(value) => setWarLogs({ ...warLogs, channel: value })}>
+                        <SelectTrigger id="log-channel">
+                          <SelectValue placeholder="Select channel" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="#war-logs">#war-logs</SelectItem>
+                          <SelectItem value="#clan-updates">#clan-updates</SelectItem>
+                          <SelectItem value="#general">#general</SelectItem>
+                          <SelectItem value="#announcements">#announcements</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-muted-foreground">
+                        Choose where war logs should be posted
+                      </p>
+                    </div>
+
+                    <Separator />
+
+                    {/* Log Options */}
+                    <div className="space-y-4">
+                      <h3 className="font-semibold text-white">Log Details</h3>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="include-attacks">Include Attack Details</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Show individual attack information in war logs
+                          </p>
+                        </div>
+                        <Switch
+                          id="include-attacks"
+                          checked={warLogs.includeAttacks}
+                          onCheckedChange={(checked) =>
+                            setWarLogs({ ...warLogs, includeAttacks: checked })
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="include-defenses">Include Defense Details</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Show defensive performance in war logs
+                          </p>
+                        </div>
+                        <Switch
+                          id="include-defenses"
+                          checked={warLogs.includeDefenses}
+                          onCheckedChange={(checked) =>
+                            setWarLogs({ ...warLogs, includeDefenses: checked })
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    {/* Notification Options */}
+                    <div className="space-y-4">
+                      <h3 className="font-semibold text-white">Notifications</h3>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="ping-loss">Ping on Loss</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Notify leadership when war is lost
+                          </p>
+                        </div>
+                        <Switch
+                          id="ping-loss"
+                          checked={warLogs.pingOnLoss}
+                          onCheckedChange={(checked) =>
+                            setWarLogs({ ...warLogs, pingOnLoss: checked })
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="celebrate-win">Celebrate Wins</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Post special celebration message when war is won
+                          </p>
+                        </div>
+                        <Switch
+                          id="celebrate-win"
+                          checked={warLogs.celebrateWin}
+                          onCheckedChange={(checked) =>
+                            setWarLogs({ ...warLogs, celebrateWin: checked })
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    {/* Preview */}
+                    <div className="space-y-2">
+                      <Label>Log Preview</Label>
+                      <div className="p-4 rounded-lg bg-gray-900 border border-gray-800">
+                        <div className="flex items-center gap-2 mb-3">
+                          <div className="w-8 h-8 rounded bg-red-600 flex items-center justify-center">
+                            <Swords className="h-4 w-4 text-white" />
+                          </div>
+                          <div>
+                            <div className="font-semibold text-white">War Result: Victory!</div>
+                            <div className="text-xs text-gray-400">Elite Warriors vs Enemy Clan</div>
+                          </div>
+                        </div>
+                        <div className="space-y-1 text-sm">
+                          <div className="flex justify-between">
+                            <span className="text-gray-400">Stars:</span>
+                            <span className="text-white font-medium">45 / 50</span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-gray-400">Destruction:</span>
+                            <span className="text-white font-medium">94.5%</span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-gray-400">Attacks Used:</span>
+                            <span className="text-white font-medium">50 / 50</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Additional Settings Card */}
+            <Card className="border-blue-500/30 bg-blue-500/5">
+              <CardHeader>
+                <CardTitle className="text-blue-400">💡 Pro Tip</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-blue-300">
+                <p>
+                  <strong>Customize your logs:</strong> Use the settings above to control what information appears in your war logs.
+                </p>
+                <p>
+                  <strong>Performance tracking:</strong> War logs help you identify top performers and areas for improvement.
+                </p>
+                <p>
+                  <strong>Historical data:</strong> All war logs are saved and can be used for generating statistics over time.
+                </p>
+              </CardContent>
+            </Card>
+
+            {/* Save Button */}
+            <div className="flex justify-end gap-4">
+              <Button variant="outline">Reset to Default</Button>
+              <Button className="bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800">
+                Save War Logs Settings
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "next-intl": "^4.4.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "recharts": "^3.4.1",
         "tailwind-merge": "^3.3.1",
         "tw-animate": "^1.0.3",
         "zustand": "^5.0.2"
@@ -3024,6 +3025,32 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
+      "integrity": "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.2.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3035,6 +3062,18 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3338,6 +3377,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3388,6 +3490,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.3",
@@ -4565,6 +4673,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4648,6 +4877,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -4943,6 +5178,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.41.0.tgz",
+      "integrity": "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5410,6 +5655,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5952,6 +6203,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5992,6 +6253,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -7605,8 +7875,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -7677,6 +7969,51 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.4.1.tgz",
+      "integrity": "sha512-35kYg6JoOgwq8sE4rhYkVWwa6aAIgOtT+Ob0gitnShjwUwZmhrmy7Jco/5kJNF4PnLXgt9Hwq+geEMS+WrjU1g==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7720,6 +8057,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8308,6 +8651,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8714,6 +9063,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "next-intl": "^4.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "recharts": "^3.4.1",
     "tailwind-merge": "^3.3.1",
     "tw-animate": "^1.0.3",
     "zustand": "^5.0.2"


### PR DESCRIPTION
Created app/[locale]/dashboard/[guildId]/wars/page.tsx with three main sections:

1. War Statistics:
   - Filterable by clan, user, Town Hall level, and date range
   - Interactive charts showing war performance, attack success rates, and war type distribution
   - Top performers leaderboard with detailed metrics
   - Summary statistics cards for wins, losses, win rate, and average stars

2. War Reminders Configuration:
   - Separate settings for Random War, Friendly War, and CWL
   - Customizable reminder timing (hours before war)
   - Role ping configuration for each war type
   - Toggle to enable/disable reminders per war type

3. War Logs Configuration:
   - Channel selection for war log posts
   - Options to include attack and defense details
   - Notification settings for losses and wins
   - Live preview of war log format

Features:
- Built with ClashKing theme colors (primary red #D90709)
- Responsive charts using recharts library
- Dark theme optimized design
- Tab-based navigation for easy access to different sections
- All comments in English
- Mock data for demonstration purposes

Dependencies added:
- recharts for data visualization