### PR TITLE
feat: add API proxy routes for Discord guilds

### DIFF
--- a/app/api/v2/guild/[guild_id]/route.ts
+++ b/app/api/v2/guild/[guild_id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+/**
+ * GET /api/v2/guild/{guild_id}
+ * Proxy request to backend to get information for a specific guild
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ guild_id: string }> }
+) {
+  try {
+    const token = request.headers.get('authorization');
+    const { guild_id } = await params;
+
+    if (!token) {
+      return NextResponse.json(
+        { detail: 'Authorization token required' },
+        { status: 401 }
+      );
+    }
+
+    const response = await fetch(`${API_BASE_URL}/v2/guild/${guild_id}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': token,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('API proxy error (GET /v2/guild/{guild_id}):', error);
+    return NextResponse.json(
+      { detail: 'Failed to fetch guild information' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/v2/guilds/route.ts
+++ b/app/api/v2/guilds/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+/**
+ * GET /api/v2/guilds
+ * Proxy request to backend to get all guilds the authenticated user has access to
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.headers.get('authorization');
+
+    if (!token) {
+      return NextResponse.json(
+        { detail: 'Authorization token required' },
+        { status: 401 }
+      );
+    }
+
+    const response = await fetch(`${API_BASE_URL}/v2/guilds`, {
+      method: 'GET',
+      headers: {
+        'Authorization': token,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('API proxy error (GET /v2/guilds):', error);
+    return NextResponse.json(
+      { detail: 'Failed to fetch guilds' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Add Next.js API routes to proxy guild-related requests to the backend:
- GET /api/v2/guilds - Get all guilds user has access to
- GET /api/v2/guild/{guild_id} - Get specific guild information

These routes forward authenticated requests to ClashKingAPI backend.

Fixes the 404 error on the servers page after Discord authentication.