### PR TITLE
feat: connect leaderboard page to API endpoints

### DIFF
--- a/app/[locale]/dashboard/[guildId]/leaderboards/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/leaderboards/page.tsx
@@ -13,22 +13,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-// Type definitions
-interface LeaderboardEntry {
-  tag: string;
-  name: string;
-  value: number;
-  rank: number;
-  clan_tag?: string;
-  clan_name?: string;
-  league?: string;
-  trophies?: number;
-}
-
-interface LeaderboardData {
-  items: LeaderboardEntry[];
-}
+import { apiClient } from "@/lib/api";
+import type { LeaderboardEntry } from "@/lib/api";
 
 const LEADERBOARD_TYPES = {
   capital: {
@@ -69,26 +55,24 @@ export default function LeaderboardsPage() {
   const fetchLeaderboard = async () => {
     setLoading(true);
     try {
-      const endpoint = leaderboardType === "player"
-        ? `/api/v1/leaderboard/players/capital`
-        : `/api/v1/leaderboard/clans/capital`;
-
-      const params = new URLSearchParams({
+      const params = {
         weekend: selectedWeekend,
         type: selectedMetric,
         league: selectedLeague,
         lower: "1",
         upper: "50"
-      });
+      };
 
-      const response = await fetch(`${endpoint}?${params}`);
+      const response = leaderboardType === "player"
+        ? await apiClient.leaderboards.getPlayerCapitalLeaderboard(params)
+        : await apiClient.leaderboards.getClanCapitalLeaderboard(params);
 
-      if (!response.ok) {
-        throw new Error('Failed to fetch leaderboard');
+      if (response.error) {
+        console.error('Error fetching leaderboard:', response.error);
+        setLeaderboardData([]);
+      } else {
+        setLeaderboardData(response.data?.items || []);
       }
-
-      const data: LeaderboardData = await response.json();
-      setLeaderboardData(data.items || []);
     } catch (error) {
       console.error('Error fetching leaderboard:', error);
       setLeaderboardData([]);

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -13,6 +13,7 @@ import { ServerClient } from './clients/server-client';
 import { LinkClient } from './clients/link-client';
 import { UtilityClient } from './clients/utility-client';
 import { RolesClient } from './clients/roles-client';
+import { LeaderboardClient } from './clients/leaderboard-client';
 
 /**
  * Main API client with all endpoints organized by domain
@@ -27,6 +28,7 @@ export class ClashKingApiClient {
   public readonly links: LinkClient;
   public readonly utils: UtilityClient;
   public readonly roles: RolesClient;
+  public readonly leaderboards: LeaderboardClient;
 
   constructor(config: ApiConfig) {
     // Initialize all specialized clients with the same config
@@ -39,6 +41,7 @@ export class ClashKingApiClient {
     this.links = new LinkClient(config);
     this.utils = new UtilityClient(config);
     this.roles = new RolesClient(config);
+    this.leaderboards = new LeaderboardClient(config);
   }
 
   /**
@@ -54,6 +57,7 @@ export class ClashKingApiClient {
     this.links.setAccessToken(token);
     this.utils.setAccessToken(token);
     this.roles.setAccessToken(token);
+    this.leaderboards.setAccessToken(token);
   }
 
   /**
@@ -69,6 +73,7 @@ export class ClashKingApiClient {
     this.links.setRefreshToken(token);
     this.utils.setRefreshToken(token);
     this.roles.setRefreshToken(token);
+    this.leaderboards.setRefreshToken(token);
   }
 
   /**
@@ -84,6 +89,7 @@ export class ClashKingApiClient {
     this.links.clearTokens();
     this.utils.clearTokens();
     this.roles.clearTokens();
+    this.leaderboards.clearTokens();
   }
 
   /**

--- a/lib/api/clients/leaderboard-client.ts
+++ b/lib/api/clients/leaderboard-client.ts
@@ -1,0 +1,52 @@
+/**
+ * Leaderboard API Client
+ */
+
+import { BaseApiClient } from '../core/base-client';
+import type { ApiResponse } from '../types/common';
+import type {
+  LeaderboardResponse,
+  LeaderboardQueryParams,
+  LeaderboardCategory,
+  LeaderboardEntityType,
+} from '../types/leaderboard';
+
+export class LeaderboardClient extends BaseApiClient {
+  /**
+   * Fetch leaderboard data for players or clans
+   */
+  async getLeaderboard(
+    category: LeaderboardCategory,
+    entityType: LeaderboardEntityType,
+    params: LeaderboardQueryParams
+  ): Promise<ApiResponse<LeaderboardResponse>> {
+    const queryString = this.buildQueryString({
+      weekend: params.weekend,
+      type: params.type,
+      league: params.league,
+      lower: params.lower,
+      upper: params.upper,
+    });
+
+    return this.request<LeaderboardResponse>(
+      `/api/v1/leaderboard/${entityType}/${category}${queryString}`,
+      {
+        method: 'GET',
+      }
+    );
+  }
+
+  /**
+   * Fetch player leaderboard for capital raids
+   */
+  async getPlayerCapitalLeaderboard(params: LeaderboardQueryParams): Promise<ApiResponse<LeaderboardResponse>> {
+    return this.getLeaderboard('capital', 'players', params);
+  }
+
+  /**
+   * Fetch clan leaderboard for capital raids
+   */
+  async getClanCapitalLeaderboard(params: LeaderboardQueryParams): Promise<ApiResponse<LeaderboardResponse>> {
+    return this.getLeaderboard('capital', 'clans', params);
+  }
+}

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Main client
-export { ClashKingApiClient, createApiClient } from './client';
+export { ClashKingApiClient, createApiClient, apiClient } from './client';
 
 // Specialized clients (for advanced usage)
 export { AuthClient } from './clients/auth-client';
@@ -17,6 +17,7 @@ export { WarClient } from './clients/war-client';
 export { ServerClient } from './clients/server-client';
 export { LinkClient } from './clients/link-client';
 export { UtilityClient } from './clients/utility-client';
+export { LeaderboardClient } from './clients/leaderboard-client';
 
 // Base client (for extending)
 export { BaseApiClient } from './core/base-client';
@@ -80,6 +81,18 @@ export type { ServerSettings, ClanSettings, BanRequest } from './types/server';
 
 // Link types
 export type { CocAccountRequest } from './types/link';
+
+// Leaderboard types
+export type {
+  LeaderboardEntry,
+  LeaderboardResponse,
+  LeaderboardQueryParams,
+  LeaderboardCategory,
+  LeaderboardEntityType,
+  PlayerCapitalMetric,
+  ClanCapitalMetric,
+  LeaderboardMetric,
+} from './types/leaderboard';
 
 // Default export
 export { createApiClient as default } from './client';

--- a/lib/api/types/leaderboard.ts
+++ b/lib/api/types/leaderboard.ts
@@ -1,0 +1,34 @@
+/**
+ * Leaderboard Types
+ */
+
+export interface LeaderboardEntry {
+  tag: string;
+  name: string;
+  value: number;
+  rank: number;
+  clan_tag?: string;
+  clan_name?: string;
+  league?: string;
+  trophies?: number;
+}
+
+export interface LeaderboardResponse {
+  items: LeaderboardEntry[];
+}
+
+export interface LeaderboardQueryParams {
+  weekend: string;
+  type: string;
+  league?: string;
+  lower?: string;
+  upper?: string;
+}
+
+export type LeaderboardCategory = 'capital';
+export type LeaderboardEntityType = 'players' | 'clans';
+
+export type PlayerCapitalMetric = 'capital_looted';
+export type ClanCapitalMetric = 'capitalTotalLoot' | 'raidsCompleted' | 'enemyDistrictsDestroyed' | 'medals';
+
+export type LeaderboardMetric = PlayerCapitalMetric | ClanCapitalMetric;


### PR DESCRIPTION
- Create LeaderboardClient with methods for fetching capital raid leaderboards
- Add comprehensive TypeScript types for leaderboard data and query parameters
- Integrate LeaderboardClient into main API client with proper token management
- Update leaderboard page to use new API client instead of direct fetch calls
- Add error handling and response validation
- Export leaderboard types and client from main API index

The leaderboard page now uses a structured API client that follows the same patterns as other clients in the codebase (PlayerClient, ClanClient, etc.)