### PR TITLE
chore: exclude app/api proxy routes from coverage and CPD

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -37,6 +37,7 @@ sonar.coverage.exclusions=\
   app/**/error.tsx,\
   app/**/loading.tsx,\
   app/**/not-found.tsx,\
+  app/api/**,\
   components/**,\
   lib/api/clients/**,\
   lib/api/index.ts,\
@@ -54,5 +55,6 @@ sonar.cpd.exclusions=\
   components/**,\
   app/**/page.tsx,\
   app/**/layout.tsx,\
+  app/api/**,\
   lib/api/clients/**,\
   lib/api-client.ts


### PR DESCRIPTION
~85 Next.js route handlers are thin proxies with no branching logic. Excluding them from coverage and duplication checks to avoid noise, consistent with lib/api/clients/** exclusion.