### PR TITLE
Improve transient GET retry handling for API client

### DIFF
--- a/lib/api/core/base-client.test.ts
+++ b/lib/api/core/base-client.test.ts
@@ -328,6 +328,50 @@ describe("BaseApiClient — request", () => {
     expect(result.status).toBe(0);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not retry transient 500 when signal aborts during backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({ detail: "Temporary upstream issue" }),
+      });
+
+      const pending = client.req("/players", { signal: controller.signal });
+      await Promise.resolve();
+      controller.abort();
+      await vi.runAllTimersAsync();
+
+      const result = await pending;
+      expect(result.error).toBe("Temporary upstream issue");
+      expect(result.status).toBe(500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry transient network error when signal aborts during backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      fetchMock.mockRejectedValueOnce(new Error("Network error"));
+
+      const pending = client.req("/players", { signal: controller.signal });
+      await Promise.resolve();
+      controller.abort();
+      await vi.runAllTimersAsync();
+
+      const result = await pending;
+      expect(result.error).toBe("Network error");
+      expect(result.status).toBe(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ─── requestFormData ─────────────────────────────────────────────────────────

--- a/lib/api/core/base-client.test.ts
+++ b/lib/api/core/base-client.test.ts
@@ -317,6 +317,17 @@ describe("BaseApiClient — request", () => {
     expect(result.data).toEqual({ recovered: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("does not retry aborted GET requests", async () => {
+    const abortError = new Error("Aborted");
+    abortError.name = "AbortError";
+    fetchMock.mockRejectedValueOnce(abortError);
+
+    const result = await client.req("/players");
+    expect(result.error).toBe("Aborted");
+    expect(result.status).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ─── requestFormData ─────────────────────────────────────────────────────────

--- a/lib/api/core/base-client.test.ts
+++ b/lib/api/core/base-client.test.ts
@@ -272,6 +272,51 @@ describe("BaseApiClient — request", () => {
     expect(result.data).toEqual({ id: 42 });
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it("retries one time on transient 500 for GET requests", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({ detail: "Temporary upstream issue" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ recovered: true }),
+      });
+
+    const result = await client.req("/players");
+    expect(result.data).toEqual({ recovered: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry transient 500 for non-GET requests", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ detail: "Temporary upstream issue" }),
+    });
+
+    const result = await client.req("/players", { method: "POST" });
+    expect(result.error).toBe("Temporary upstream issue");
+    expect(result.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries one time on transient network failure for GET requests", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ recovered: true }),
+      });
+
+    const result = await client.req("/players");
+    expect(result.data).toEqual({ recovered: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ─── requestFormData ─────────────────────────────────────────────────────────

--- a/lib/api/core/base-client.ts
+++ b/lib/api/core/base-client.ts
@@ -6,12 +6,33 @@ import type { ApiConfig, ApiResponse } from '../types/common';
 
 // Module-level singleton so all client instances share one refresh attempt
 let _sharedRefreshPromise: Promise<boolean> | null = null;
+const MAX_TRANSIENT_GET_RETRIES = 1;
+const TRANSIENT_RETRYABLE_STATUS = new Set([500, 502, 503, 504]);
+
+interface RequestRetryState {
+  authRetried: boolean;
+  transientRetried: number;
+}
 
 function extractErrorMessage(data: any, status: number): string {
   const detail = data?.detail;
   if (Array.isArray(detail)) return detail.map((e: any) => e.msg ?? String(e)).join(', ');
   if (typeof detail === 'string') return detail;
   return data?.message || `HTTP ${status}`;
+}
+
+function canRetryTransientError(method: string, status: number): boolean {
+  return method === 'GET' && TRANSIENT_RETRYABLE_STATUS.has(status);
+}
+
+function getRequestMethod(options: RequestInit): string {
+  return (options.method || 'GET').toUpperCase();
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 export class BaseApiClient {
@@ -49,16 +70,17 @@ export class BaseApiClient {
   protected async request<T>(
     endpoint: string,
     options: RequestInit = {},
-    _isRetry = false
+    retryState: RequestRetryState = { authRetried: false, transientRetried: 0 }
   ): Promise<ApiResponse<T>> {
     const url = `${this.config.baseUrl}${endpoint}`;
     const headers = new Headers(options.headers);
+    const method = getRequestMethod(options);
 
     if (!headers.has('Content-Type')) {
       headers.set('Content-Type', 'application/json');
     }
 
-    const token = await this._getToken(_isRetry, endpoint.startsWith('/v2/auth/'));
+    const token = await this._getToken(retryState.authRetried, endpoint.startsWith('/v2/auth/'));
 
     if (token && !headers.has('Authorization')) {
       headers.set('Authorization', `Bearer ${token}`);
@@ -76,14 +98,28 @@ export class BaseApiClient {
         // Only retry on 401. A 403 is often a real permissions failure and should not trigger refresh.
         if (
           response.status === 401 &&
-          !_isRetry &&
+          !retryState.authRetried &&
           !endpoint.startsWith('/v2/auth/') &&
           globalThis.window !== undefined
         ) {
           const refreshed = await this._tryRefreshToken();
           if (refreshed) {
-            return this.request<T>(endpoint, options, true);
+            return this.request<T>(endpoint, options, {
+              ...retryState,
+              authRetried: true,
+            });
           }
+        }
+
+        if (
+          canRetryTransientError(method, response.status) &&
+          retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES
+        ) {
+          await wait(250 * (retryState.transientRetried + 1));
+          return this.request<T>(endpoint, options, {
+            ...retryState,
+            transientRetried: retryState.transientRetried + 1,
+          });
         }
 
         return { error: extractErrorMessage(data, response.status), status: response.status };
@@ -94,6 +130,14 @@ export class BaseApiClient {
         status: response.status,
       };
     } catch (error) {
+      if (method === 'GET' && retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES) {
+        await wait(250 * (retryState.transientRetried + 1));
+        return this.request<T>(endpoint, options, {
+          ...retryState,
+          transientRetried: retryState.transientRetried + 1,
+        });
+      }
+
       return {
         error: error instanceof Error ? error.message : 'Network error',
         status: 0,

--- a/lib/api/core/base-client.ts
+++ b/lib/api/core/base-client.ts
@@ -70,8 +70,9 @@ export class BaseApiClient {
   protected async request<T>(
     endpoint: string,
     options: RequestInit = {},
-    retryState: RequestRetryState = { authRetried: false, transientRetried: 0 }
+    retryState?: RequestRetryState
   ): Promise<ApiResponse<T>> {
+    const state = this._resolveRetryState(retryState);
     const url = `${this.config.baseUrl}${endpoint}`;
     const headers = new Headers(options.headers);
     const method = getRequestMethod(options);
@@ -80,7 +81,7 @@ export class BaseApiClient {
       headers.set('Content-Type', 'application/json');
     }
 
-    const token = await this._getToken(retryState.authRetried, endpoint.startsWith('/v2/auth/'));
+    const token = await this._getToken(state.authRetried, endpoint.startsWith('/v2/auth/'));
 
     if (token && !headers.has('Authorization')) {
       headers.set('Authorization', `Bearer ${token}`);
@@ -95,32 +96,11 @@ export class BaseApiClient {
       const data = await response.json().catch(() => null);
 
       if (!response.ok) {
-        // Only retry on 401. A 403 is often a real permissions failure and should not trigger refresh.
-        if (
-          response.status === 401 &&
-          !retryState.authRetried &&
-          !endpoint.startsWith('/v2/auth/') &&
-          globalThis.window !== undefined
-        ) {
-          const refreshed = await this._tryRefreshToken();
-          if (refreshed) {
-            return this.request<T>(endpoint, options, {
-              ...retryState,
-              authRetried: true,
-            });
-          }
-        }
+        const authRetry = await this._retryOnUnauthorized<T>(endpoint, options, response.status, state);
+        if (authRetry) return authRetry;
 
-        if (
-          canRetryTransientError(method, response.status) &&
-          retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES
-        ) {
-          await wait(250 * (retryState.transientRetried + 1));
-          return this.request<T>(endpoint, options, {
-            ...retryState,
-            transientRetried: retryState.transientRetried + 1,
-          });
-        }
+        const transientRetry = await this._retryOnTransientFailure<T>(endpoint, options, method, response.status, state);
+        if (transientRetry) return transientRetry;
 
         return { error: extractErrorMessage(data, response.status), status: response.status };
       }
@@ -130,19 +110,78 @@ export class BaseApiClient {
         status: response.status,
       };
     } catch (error) {
-      if (method === 'GET' && retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES) {
-        await wait(250 * (retryState.transientRetried + 1));
-        return this.request<T>(endpoint, options, {
-          ...retryState,
-          transientRetried: retryState.transientRetried + 1,
-        });
-      }
+      const transientRetry = await this._retryOnNetworkException<T>(endpoint, options, method, state);
+      if (transientRetry) return transientRetry;
 
       return {
         error: error instanceof Error ? error.message : 'Network error',
         status: 0,
       };
     }
+  }
+
+  private _resolveRetryState(retryState?: RequestRetryState): RequestRetryState {
+    return retryState ?? { authRetried: false, transientRetried: 0 };
+  }
+
+  // A concrete ApiResponse is always truthy; undefined signals "no retry performed".
+  private async _retryOnUnauthorized<T>(
+    endpoint: string,
+    options: RequestInit,
+    status: number,
+    retryState: RequestRetryState
+  ): Promise<ApiResponse<T> | undefined> {
+    const shouldRetryAuth =
+      status === 401 &&
+      !retryState.authRetried &&
+      !endpoint.startsWith('/v2/auth/') &&
+      globalThis.window !== undefined;
+
+    if (!shouldRetryAuth) return undefined;
+
+    const refreshed = await this._tryRefreshToken();
+    if (!refreshed) return undefined;
+
+    return this.request<T>(endpoint, options, {
+      ...retryState,
+      authRetried: true,
+    });
+  }
+
+  private async _retryOnTransientFailure<T>(
+    endpoint: string,
+    options: RequestInit,
+    method: string,
+    status: number,
+    retryState: RequestRetryState
+  ): Promise<ApiResponse<T> | undefined> {
+    const canRetry =
+      canRetryTransientError(method, status) &&
+      retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES;
+
+    if (!canRetry) return undefined;
+
+    await wait(250 * (retryState.transientRetried + 1));
+    return this.request<T>(endpoint, options, {
+      ...retryState,
+      transientRetried: retryState.transientRetried + 1,
+    });
+  }
+
+  private async _retryOnNetworkException<T>(
+    endpoint: string,
+    options: RequestInit,
+    method: string,
+    retryState: RequestRetryState
+  ): Promise<ApiResponse<T> | undefined> {
+    const canRetry = method === 'GET' && retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES;
+    if (!canRetry) return undefined;
+
+    await wait(250 * (retryState.transientRetried + 1));
+    return this.request<T>(endpoint, options, {
+      ...retryState,
+      transientRetried: retryState.transientRetried + 1,
+    });
   }
 
   /**

--- a/lib/api/core/base-client.ts
+++ b/lib/api/core/base-client.ts
@@ -35,6 +35,26 @@ function wait(ms: number): Promise<void> {
   });
 }
 
+function waitForRetryBackoff(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (!signal) return wait(ms).then(() => true);
+  if (signal.aborted) return Promise.resolve(false);
+
+  return new Promise((resolve) => {
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve(true);
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener('abort', onAbort);
+      resolve(false);
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 function isAbortError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   return 'name' in error && (error as { name?: string }).name === 'AbortError';
@@ -166,7 +186,12 @@ export class BaseApiClient {
 
     if (!canRetry) return undefined;
 
-    await wait(250 * (retryState.transientRetried + 1));
+    const shouldRetry = await waitForRetryBackoff(
+      250 * (retryState.transientRetried + 1),
+      options.signal
+    );
+    if (!shouldRetry) return undefined;
+
     return this.request<T>(endpoint, options, {
       ...retryState,
       transientRetried: retryState.transientRetried + 1,
@@ -186,7 +211,12 @@ export class BaseApiClient {
       !isAbortError(error);
     if (!canRetry) return undefined;
 
-    await wait(250 * (retryState.transientRetried + 1));
+    const shouldRetry = await waitForRetryBackoff(
+      250 * (retryState.transientRetried + 1),
+      options.signal
+    );
+    if (!shouldRetry) return undefined;
+
     return this.request<T>(endpoint, options, {
       ...retryState,
       transientRetried: retryState.transientRetried + 1,

--- a/lib/api/core/base-client.ts
+++ b/lib/api/core/base-client.ts
@@ -35,6 +35,11 @@ function wait(ms: number): Promise<void> {
   });
 }
 
+function isAbortError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  return 'name' in error && (error as { name?: string }).name === 'AbortError';
+}
+
 export class BaseApiClient {
   protected config: ApiConfig;
 
@@ -110,7 +115,7 @@ export class BaseApiClient {
         status: response.status,
       };
     } catch (error) {
-      const transientRetry = await this._retryOnNetworkException<T>(endpoint, options, method, state);
+      const transientRetry = await this._retryOnNetworkException<T>(endpoint, options, method, state, error);
       if (transientRetry) return transientRetry;
 
       return {
@@ -172,9 +177,13 @@ export class BaseApiClient {
     endpoint: string,
     options: RequestInit,
     method: string,
-    retryState: RequestRetryState
+    retryState: RequestRetryState,
+    error: unknown
   ): Promise<ApiResponse<T> | undefined> {
-    const canRetry = method === 'GET' && retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES;
+    const canRetry =
+      method === 'GET' &&
+      retryState.transientRetried < MAX_TRANSIENT_GET_RETRIES &&
+      !isAbortError(error);
     if (!canRetry) return undefined;
 
     await wait(250 * (retryState.transientRetried + 1));

--- a/lib/api/core/base-client.ts
+++ b/lib/api/core/base-client.ts
@@ -35,7 +35,7 @@ function wait(ms: number): Promise<void> {
   });
 }
 
-function waitForRetryBackoff(ms: number, signal?: AbortSignal): Promise<boolean> {
+function waitForRetryBackoff(ms: number, signal?: AbortSignal | null): Promise<boolean> {
   if (!signal) return wait(ms).then(() => true);
   if (signal.aborted) return Promise.resolve(false);
 


### PR DESCRIPTION
To retry at least once with a 500 error