### PR TITLE
Polish dashboard loading states and mobile tab layout

### DIFF
--- a/app/[locale]/dashboard/[guildId]/family-settings/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/family-settings/page.tsx
@@ -569,7 +569,7 @@ export default function FamilySettingsPage() {
                   {t("nickname.familyFormat")}
                 </Label>
                 {isLoading ? (
-                  <Skeleton className="h-10 w-full animate-pulse" />
+                  <Skeleton className="h-9 w-full animate-pulse" />
                 ) : (
                   <Input
                     id="family-convention"
@@ -588,13 +588,17 @@ export default function FamilySettingsPage() {
                     <Eye className="h-4 w-4 text-primary" />
                     <p className="text-xs font-medium text-primary">{t("nickname.preview")}</p>
                   </div>
-                  {isLoading ? (
-                    <Skeleton className="h-9 w-full animate-pulse" />
-                  ) : (
-                    <p className="text-sm font-mono bg-background/50 border border-border rounded px-3 py-2">
-                      {generatePreview(settings.nickname_rule)}
-                    </p>
-                  )}
+                  <div className="h-9 w-full rounded border border-border bg-background/50 px-3">
+                    {isLoading ? (
+                      <div className="flex h-full items-center">
+                        <Skeleton className="h-4 w-2/3 animate-pulse" />
+                      </div>
+                    ) : (
+                      <p className="flex h-full items-center truncate text-sm font-mono">
+                        {generatePreview(settings.nickname_rule)}
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -653,7 +657,7 @@ export default function FamilySettingsPage() {
                   {t("nickname.nonFamilyFormat")}
                 </Label>
                 {isLoading ? (
-                  <Skeleton className="h-10 w-full animate-pulse" />
+                  <Skeleton className="h-9 w-full animate-pulse" />
                 ) : (
                   <Input
                     id="non-family-convention"
@@ -672,13 +676,17 @@ export default function FamilySettingsPage() {
                     <Eye className="h-4 w-4 text-primary" />
                     <p className="text-xs font-medium text-primary">{t("nickname.preview")}</p>
                   </div>
-                  {isLoading ? (
-                    <Skeleton className="h-9 w-full animate-pulse" />
-                  ) : (
-                    <p className="text-sm font-mono bg-background/50 border border-border rounded px-3 py-2">
-                      {generatePreview(settings.non_family_nickname_rule)}
-                    </p>
-                  )}
+                  <div className="h-9 w-full rounded border border-border bg-background/50 px-3">
+                    {isLoading ? (
+                      <div className="flex h-full items-center">
+                        <Skeleton className="h-4 w-2/3 animate-pulse" />
+                      </div>
+                    ) : (
+                      <p className="flex h-full items-center truncate text-sm font-mono">
+                        {generatePreview(settings.non_family_nickname_rule)}
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/app/[locale]/dashboard/[guildId]/giveaways/GiveawaysClient.tsx
+++ b/app/[locale]/dashboard/[guildId]/giveaways/GiveawaysClient.tsx
@@ -282,10 +282,25 @@ function GiveawaysMainContent({
           <CardHeader><CardTitle>{listTitle}</CardTitle><CardDescription>{listDescription}</CardDescription></CardHeader>
           <CardContent>
             <Tabs value="ongoing">
-              <TabsList className="grid w-full grid-cols-3 md:w-auto">
-                <TabsTrigger value="ongoing">{tabs.ongoing}</TabsTrigger>
-                <TabsTrigger value="upcoming">{tabs.upcoming}</TabsTrigger>
-                <TabsTrigger value="ended">{tabs.ended}</TabsTrigger>
+              <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-3 sm:gap-0">
+                <TabsTrigger value="ongoing" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                  <span className="truncate">{tabs.ongoing}</span>
+                  <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-green-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                    <Skeleton className="h-2.5 w-2.5 rounded-[2px]" />
+                  </span>
+                </TabsTrigger>
+                <TabsTrigger value="upcoming" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                  <span className="truncate">{tabs.upcoming}</span>
+                  <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-amber-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                    <Skeleton className="h-2.5 w-2.5 rounded-[2px]" />
+                  </span>
+                </TabsTrigger>
+                <TabsTrigger value="ended" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                  <span className="truncate">{tabs.ended}</span>
+                  <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-slate-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                    <Skeleton className="h-2.5 w-2.5 rounded-[2px]" />
+                  </span>
+                </TabsTrigger>
               </TabsList>
             </Tabs>
             <div className="mt-6 space-y-3">
@@ -337,10 +352,25 @@ function GiveawaysMainContent({
         <CardHeader><CardTitle>{t("listTitle")}</CardTitle><CardDescription>{t("listDescription")}</CardDescription></CardHeader>
         <CardContent>
           <Tabs value={activeTab} onValueChange={onActiveTabChange}>
-            <TabsList className="grid w-full grid-cols-3 md:w-auto">
-              <TabsTrigger value="ongoing">{t("tabs.ongoing")}{giveaways.ongoing.length > 0 && <span className="ml-1.5 rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-semibold text-primary">{giveaways.ongoing.length}</span>}</TabsTrigger>
-              <TabsTrigger value="upcoming">{t("tabs.upcoming")}{giveaways.upcoming.length > 0 && <span className="ml-1.5 rounded-full bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-amber-500">{giveaways.upcoming.length}</span>}</TabsTrigger>
-              <TabsTrigger value="ended">{t("tabs.ended")}{giveaways.ended.length > 0 && <span className="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">{giveaways.ended.length}</span>}</TabsTrigger>
+            <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-3 sm:gap-0">
+              <TabsTrigger value="ongoing" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <span className="truncate">{t("tabs.ongoing")}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-green-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {giveaways.ongoing.length}
+                </span>
+              </TabsTrigger>
+              <TabsTrigger value="upcoming" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <span className="truncate">{t("tabs.upcoming")}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-amber-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {giveaways.upcoming.length}
+                </span>
+              </TabsTrigger>
+              <TabsTrigger value="ended" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <span className="truncate">{t("tabs.ended")}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-slate-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {giveaways.ended.length}
+                </span>
+              </TabsTrigger>
             </TabsList>
             <TabsContent value="ongoing" className="mt-6">
               <GiveawaysTable

--- a/app/[locale]/dashboard/[guildId]/panels/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/panels/page.tsx
@@ -426,8 +426,7 @@ export default function PanelsPage() {
     buttonStyle: draftButtonStyle,
     previewNoButtonsText: t("previewNoButtons"),
   });
-  const isWelcomeChannelResolving = isChannelsLoading || isPanelLoading;
-  const shouldShowWelcomeChannelSkeleton = isWelcomeChannelResolving;
+  const shouldShowWelcomeChannelSkeleton = isChannelsLoading;
 
   return (
     <div className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">

--- a/app/[locale]/dashboard/[guildId]/panels/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/panels/page.tsx
@@ -186,6 +186,7 @@ export default function PanelsPage() {
   const { toast } = useToast();
 
   const [isPanelLoading, setIsPanelLoading] = useState(true);
+  const [isPanelSnapshotInitialized, setIsPanelSnapshotInitialized] = useState(false);
   const [isEmbedsLoading, setIsEmbedsLoading] = useState(true);
   const [isChannelsLoading, setIsChannelsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -233,6 +234,7 @@ export default function PanelsPage() {
     setButtons(nextPayload.buttons);
     setButtonColor(nextPayload.button_color);
     setWelcomeChannel(nextPayload.welcome_channel ?? "");
+    setIsPanelSnapshotInitialized(true);
   }, []);
 
   const queuePanelUpdate = useCallback(
@@ -271,6 +273,9 @@ export default function PanelsPage() {
 
       if (panelRes.data) {
         applyPanelData(panelRes.data);
+      } else {
+        // No panel configured yet; treat the default snapshot as initialized.
+        setIsPanelSnapshotInitialized(true);
       }
     } catch {
       showLoadError();
@@ -331,6 +336,10 @@ export default function PanelsPage() {
   };
 
   const handleWelcomeChannelChange = async (nextChannel: string) => {
+    if (isPanelLoading || !isPanelSnapshotInitialized) {
+      return;
+    }
+
     const previousChannel = welcomeChannel;
     setWelcomeChannel(nextChannel);
     setIsSavingWelcomeChannel(true);
@@ -341,11 +350,12 @@ export default function PanelsPage() {
         ...snapshot,
         welcome_channel: nextWelcomeChannel,
       }));
+      const autosaveDescription = !nextChannel || nextChannel === "disabled"
+        ? t("welcomeAutosaveDisabled")
+        : t("welcomeAutosaveSuccess");
       toast({
         title: tCommon("success"),
-        description: !nextChannel || nextChannel === "disabled"
-          ? t("welcomeAutosaveDisabled")
-          : t("welcomeAutosaveSuccess"),
+        description: autosaveDescription,
       });
     } catch (err) {
       setWelcomeChannel(previousChannel);
@@ -426,7 +436,7 @@ export default function PanelsPage() {
     buttonStyle: draftButtonStyle,
     previewNoButtonsText: t("previewNoButtons"),
   });
-  const shouldShowWelcomeChannelSkeleton = isChannelsLoading;
+  const shouldShowWelcomeChannelSkeleton = isChannelsLoading || isPanelLoading || !isPanelSnapshotInitialized;
 
   return (
     <div className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">

--- a/app/[locale]/dashboard/[guildId]/reminders/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/reminders/page.tsx
@@ -658,6 +658,13 @@ export default function RemindersPage() { // NOSONAR — React page component: c
   }
 
   const currentReminders = getCurrentReminders();
+  const getVisibleCount = (items: ReminderConfig[]) => (
+    selectedClan === "all" ? items.length : items.filter((reminder) => reminder.clan_tag === selectedClan).length
+  );
+  const warReminderCount = getVisibleCount(reminders.war_reminders);
+  const capitalReminderCount = getVisibleCount(reminders.capital_reminders);
+  const gamesReminderCount = getVisibleCount(reminders.clan_games_reminders);
+  const inactivityReminderCount = getVisibleCount(reminders.inactivity_reminders);
 
   return (
       <div className="min-h-[calc(100vh+1px)] bg-background p-4 md:p-6">
@@ -793,50 +800,34 @@ export default function RemindersPage() { // NOSONAR — React page component: c
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-            <TabsList className="grid w-full grid-cols-2 md:grid-cols-4 lg:w-[800px] h-auto">
-              <TabsTrigger value="war" className="gap-2">
-                <Target className="h-4 w-4" />
-                {t('tabs.war')}
-                {reminders.war_reminders.length > 0 && (
-                    <Badge variant="secondary" className="ml-1 bg-red-500/20 text-red-500">
-                      {selectedClan === "all"
-                          ? reminders.war_reminders.length
-                          : reminders.war_reminders.filter(r => r.clan_tag === selectedClan).length}
-                    </Badge>
-                )}
+            <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-2 lg:grid-cols-4 sm:gap-0">
+              <TabsTrigger value="war" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Target className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{t('tabs.war')}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-red-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : warReminderCount}
+                </span>
               </TabsTrigger>
-              <TabsTrigger value="capital" className="gap-2">
-                <Castle className="h-4 w-4" />
-                {t('tabs.capital')}
-                {reminders.capital_reminders.length > 0 && (
-                    <Badge variant="secondary" className="ml-1 bg-purple-500/20 text-purple-500">
-                      {selectedClan === "all"
-                          ? reminders.capital_reminders.length
-                          : reminders.capital_reminders.filter(r => r.clan_tag === selectedClan).length}
-                    </Badge>
-                )}
+              <TabsTrigger value="capital" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Castle className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{t('tabs.capital')}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-purple-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : capitalReminderCount}
+                </span>
               </TabsTrigger>
-              <TabsTrigger value="games" className="gap-2">
-                <Calendar className="h-4 w-4" />
-                {t('tabs.clanGames')}
-                {reminders.clan_games_reminders.length > 0 && (
-                    <Badge variant="secondary" className="ml-1 bg-green-500/20 text-green-500">
-                      {selectedClan === "all"
-                          ? reminders.clan_games_reminders.length
-                          : reminders.clan_games_reminders.filter(r => r.clan_tag === selectedClan).length}
-                    </Badge>
-                )}
+              <TabsTrigger value="games" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Calendar className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{t('tabs.clanGames')}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-green-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : gamesReminderCount}
+                </span>
               </TabsTrigger>
-              <TabsTrigger value="inactivity" className="gap-2">
-                <UserX className="h-4 w-4" />
-                {t('tabs.inactivity')}
-                {reminders.inactivity_reminders.length > 0 && (
-                    <Badge variant="secondary" className="ml-1 bg-orange-500/20 text-orange-500">
-                      {selectedClan === "all"
-                          ? reminders.inactivity_reminders.length
-                          : reminders.inactivity_reminders.filter(r => r.clan_tag === selectedClan).length}
-                    </Badge>
-                )}
+              <TabsTrigger value="inactivity" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <UserX className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{t('tabs.inactivity')}</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-orange-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : inactivityReminderCount}
+                </span>
               </TabsTrigger>
             </TabsList>
 

--- a/app/[locale]/dashboard/[guildId]/roles/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/roles/page.tsx
@@ -61,6 +61,13 @@ const ROLE_TYPES_CONFIG: Array<{ value: RoleType; icon: any }> = [
   { value: "builder_league", icon: Award },
 ];
 
+const ROLE_TYPE_COUNT_BADGE_CLASS: Record<"townhall" | "league" | "builderhall" | "builder_league", string> = {
+  townhall: "bg-blue-600",
+  league: "bg-green-600",
+  builderhall: "bg-amber-600",
+  builder_league: "bg-purple-600",
+};
+
 const BUILDER_LEAGUE_TIERS = [
   { id: "diamond", apiName: "Diamond", range: null },
   { id: "ruby", apiName: "Ruby", range: [1, 3] },
@@ -355,25 +362,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
       setDialogError(null);
 
       // Duplicate check before hitting the API
-      const existingRoles: any[] = allRoles[currentRoleType] || [];
-      let matchesCriterion = false;
-      let matchesExact = false;
-
-      if (currentRoleType === "townhall") {
-        matchesCriterion = existingRoles.some((r) => r.th === newRole.th);
-        matchesExact = existingRoles.some((r) => r.th === newRole.th && r.role_id === newRole.role_id);
-      } else if (currentRoleType === "league") {
-        matchesCriterion = existingRoles.some((r) => r.type === newRole.league);
-        matchesExact = existingRoles.some((r) => r.type === newRole.league && r.role_id === newRole.role_id);
-      } else if (currentRoleType === "builderhall") {
-        const normBh = (bh: any) =>
-          typeof bh === "string" ? Number.parseInt(bh.replace(/^bh/i, "")) : Number(bh);
-        matchesCriterion = existingRoles.some((r) => normBh(r.bh) === newRole.bh);
-        matchesExact = existingRoles.some((r) => normBh(r.bh) === newRole.bh && r.role_id === newRole.role_id);
-      } else if (currentRoleType === "builder_league") {
-        matchesCriterion = existingRoles.some((r) => r.type === newRole.builder_league);
-        matchesExact = existingRoles.some((r) => r.type === newRole.builder_league && r.role_id === newRole.role_id);
-      }
+      const { matchesCriterion, matchesExact } = getRoleDuplicateState();
 
       if (matchesExact) {
         setDialogError(t("addRoleDialog.errorDuplicateExact"));
@@ -443,14 +432,15 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
   };
 
   const renderRoleForm = () => {
+    const duplicateExactSelected = duplicateState.matchesExact;
     switch (currentRoleType) {
       case "townhall":
         return (
           <>
             <div className="space-y-2">
-              <Label htmlFor="th">{t("addRoleDialog.townHallLevel")}</Label>
+              <Label htmlFor="th">{t("addRoleDialog.townHallLevel")}<span className="ml-1 text-destructive">*</span></Label>
               <Select
-                value={newRole.th?.toString()}
+                value={newRole.th !== undefined && newRole.th !== null ? newRole.th.toString() : ""}
                 onValueChange={(value) => setNewRole({ ...newRole, th: Number.parseInt(value) })}
               >
                 <SelectTrigger id="th">
@@ -466,7 +456,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="role">{t("addRoleDialog.discordRole")}</Label>
+              <Label htmlFor="role">{t("addRoleDialog.discordRole")}<span className="ml-1 text-destructive">*</span></Label>
               <RoleCombobox
                 roles={discordRoles}
                 value={newRole.role_id?.toString() || ""}
@@ -474,6 +464,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
                 placeholder={t("addRoleDialog.selectRole")}
                 showDisabled={false}
               />
+              {duplicateExactSelected && (
+                <p className="text-xs text-destructive">{t("addRoleDialog.errorDuplicateExact")}</p>
+              )}
             </div>
           </>
         );
@@ -482,9 +475,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
         return (
           <>
             <div className="space-y-2">
-              <Label htmlFor="league">{t("addRoleDialog.league")}</Label>
+              <Label htmlFor="league">{t("addRoleDialog.league")}<span className="ml-1 text-destructive">*</span></Label>
               <Select
-                value={newRole.league}
+                value={newRole.league ?? ""}
                 onValueChange={(value) => setNewRole({ ...newRole, league: value })}
               >
                 <SelectTrigger id="league">
@@ -500,7 +493,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="role">{t("addRoleDialog.discordRole")}</Label>
+              <Label htmlFor="role">{t("addRoleDialog.discordRole")}<span className="ml-1 text-destructive">*</span></Label>
               <RoleCombobox
                 roles={discordRoles}
                 value={newRole.role_id?.toString() || ""}
@@ -508,6 +501,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
                 placeholder={t("addRoleDialog.selectRole")}
                 showDisabled={false}
               />
+              {duplicateExactSelected && (
+                <p className="text-xs text-destructive">{t("addRoleDialog.errorDuplicateExact")}</p>
+              )}
             </div>
           </>
         );
@@ -516,9 +512,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
         return (
           <>
             <div className="space-y-2">
-              <Label htmlFor="bh">{t("addRoleDialog.builderHallLevel")}</Label>
+              <Label htmlFor="bh">{t("addRoleDialog.builderHallLevel")}<span className="ml-1 text-destructive">*</span></Label>
               <Select
-                value={newRole.bh?.toString()}
+                value={newRole.bh !== undefined && newRole.bh !== null ? newRole.bh.toString() : ""}
                 onValueChange={(value) => setNewRole({ ...newRole, bh: Number.parseInt(value) })}
               >
                 <SelectTrigger id="bh">
@@ -534,7 +530,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="role">{t("addRoleDialog.discordRole")}</Label>
+              <Label htmlFor="role">{t("addRoleDialog.discordRole")}<span className="ml-1 text-destructive">*</span></Label>
               <RoleCombobox
                 roles={discordRoles}
                 value={newRole.role_id?.toString() || ""}
@@ -542,6 +538,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
                 placeholder={t("addRoleDialog.selectRole")}
                 showDisabled={false}
               />
+              {duplicateExactSelected && (
+                <p className="text-xs text-destructive">{t("addRoleDialog.errorDuplicateExact")}</p>
+              )}
             </div>
           </>
         );
@@ -550,9 +549,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
         return (
           <>
             <div className="space-y-2">
-              <Label htmlFor="builder_league">{t("addRoleDialog.builderLeague")}</Label>
+              <Label htmlFor="builder_league">{t("addRoleDialog.builderLeague")}<span className="ml-1 text-destructive">*</span></Label>
               <Select
-                value={newRole.builder_league}
+                value={newRole.builder_league ?? ""}
                 onValueChange={(value) => setNewRole({ ...newRole, builder_league: value })}
               >
                 <SelectTrigger id="builder_league">
@@ -568,7 +567,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="role">{t("addRoleDialog.discordRole")}</Label>
+              <Label htmlFor="role">{t("addRoleDialog.discordRole")}<span className="ml-1 text-destructive">*</span></Label>
               <RoleCombobox
                 roles={discordRoles}
                 value={newRole.role_id?.toString() || ""}
@@ -576,6 +575,9 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
                 placeholder={t("addRoleDialog.selectRole")}
                 showDisabled={false}
               />
+              {duplicateExactSelected && (
+                <p className="text-xs text-destructive">{t("addRoleDialog.errorDuplicateExact")}</p>
+              )}
             </div>
           </>
         );
@@ -702,12 +704,39 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
   const activeRoleTypes = Object.entries(allRoles).filter(([_, roles]: [string, any]) => roles.length > 0).length;
   const totalRoleTypes = 4; // townhall, league, builderhall, builder_league
 
+  const getRoleDuplicateState = () => {
+    const existingRoles: any[] = allRoles[currentRoleType] || [];
+    let matchesCriterion = false;
+    let matchesExact = false;
+
+    if (currentRoleType === "townhall") {
+      matchesCriterion = existingRoles.some((r) => r.th === newRole.th);
+      matchesExact = existingRoles.some((r) => r.th === newRole.th && r.role_id === newRole.role_id);
+    } else if (currentRoleType === "league") {
+      matchesCriterion = existingRoles.some((r) => r.type === newRole.league);
+      matchesExact = existingRoles.some((r) => r.type === newRole.league && r.role_id === newRole.role_id);
+    } else if (currentRoleType === "builderhall") {
+      const normBh = (bh: any) =>
+        typeof bh === "string" ? Number.parseInt(bh.replace(/^bh/i, "")) : Number(bh);
+      matchesCriterion = existingRoles.some((r) => normBh(r.bh) === newRole.bh);
+      matchesExact = existingRoles.some((r) => normBh(r.bh) === newRole.bh && r.role_id === newRole.role_id);
+    } else if (currentRoleType === "builder_league") {
+      matchesCriterion = existingRoles.some((r) => r.type === newRole.builder_league);
+      matchesExact = existingRoles.some((r) => r.type === newRole.builder_league && r.role_id === newRole.role_id);
+    }
+
+    return { matchesCriterion, matchesExact };
+  };
+
+  const duplicateState = getRoleDuplicateState();
+
   const hasChanged = roleSettings.auto_eval_status !== originalRoleSettings.auto_eval_status ||
     roleSettings.auto_eval_nickname !== originalRoleSettings.auto_eval_nickname;
 
   const isAddRoleDisabled = () => {
     const hasRole = !!newRole.role_id;
     if (!hasRole) return true;
+    if (duplicateState.matchesExact) return true;
 
     switch (currentRoleType) {
       case "townhall": return !newRole.th;
@@ -933,7 +962,7 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
                   </DialogHeader>
                   <div className="space-y-4 py-4">
                     <div className="space-y-2">
-                      <Label htmlFor="role-type">{t("addRoleDialog.roleType")}</Label>
+                      <Label htmlFor="role-type">{t("addRoleDialog.roleType")}<span className="ml-1 text-destructive">*</span></Label>
                       <Select
                         value={currentRoleType}
                         onValueChange={(value) => {
@@ -983,15 +1012,20 @@ export default function RolesPage() { // NOSONAR — complexity comes from aggre
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="townhall" className="w-full">
-              <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 lg:grid-cols-4 h-auto">
+              <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-2 lg:grid-cols-4 sm:gap-0">
                 {roleTypes.map((type) => (
                   <TabsTrigger
                     key={type.value}
                     value={type.value}
-                    className="text-xs lg:text-sm whitespace-normal break-words text-center leading-tight"
+                    className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm"
                   >
-                    <type.icon className="mr-1 lg:mr-2 h-3.5 w-3.5 lg:h-4 lg:w-4 shrink-0" />
-                    <span className="leading-tight">{type.label}</span>
+                    <type.icon className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{type.label}</span>
+                    <span
+                      className={`inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] px-1 text-[11px] font-semibold leading-none text-white shadow-sm ${ROLE_TYPE_COUNT_BADGE_CLASS[type.value as "townhall" | "league" | "builderhall" | "builder_league"]}`}
+                    >
+                      {isLoading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : (allRoles[type.value]?.length ?? 0)}
+                    </span>
                   </TabsTrigger>
                 ))}
               </TabsList>

--- a/app/[locale]/dashboard/[guildId]/tickets/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/tickets/page.tsx
@@ -875,7 +875,10 @@ function TicketsTab({
           <div className="space-y-1">
             <CardTitle className="text-base">{t("tabTickets")}</CardTitle>
             <CardDescription>
-              {t("showing", { count: displayed.length, total: allTickets.length })}
+              {isLoading
+                ? <Skeleton className="h-4 w-40 animate-pulse" />
+                : t("showing", { count: displayed.length, total: allTickets.length })
+              }
             </CardDescription>
           </div>
           <Button variant="outline" size="icon" onClick={() => fetchTickets(true)} disabled={isRefreshing}>

--- a/app/[locale]/servers/page.tsx
+++ b/app/[locale]/servers/page.tsx
@@ -122,6 +122,14 @@ export default function ServersPage() {
 
   const handleGuildClick = (guild: GuildInfo) => {
     if (guild.has_bot) {
+      sessionStorage.setItem(
+        "selected_guild",
+        JSON.stringify({
+          id: guild.id,
+          name: guild.name,
+          icon: getGuildIconUrl(guild) || undefined,
+        })
+      );
       router.push(`/${locale}/dashboard/${guild.id}`);
     }
   };

--- a/components/dashboard/bot-stats.tsx
+++ b/components/dashboard/bot-stats.tsx
@@ -47,18 +47,24 @@ export function BotStats() {
         fetchBotInfo();
     }, []);
 
-    const isOnline = !isLoading && botInfo;
-    const statusStyles = isOnline
+    const isOnline = Boolean(!isLoading && botInfo);
+    const statusStyles = isLoading
         ? {
-            iconBg: "bg-green-500/10",
-            iconColor: "text-green-500",
-            badgeBg: "bg-green-500 hover:bg-green-600"
+            iconBg: "bg-muted",
+            iconColor: "text-muted-foreground/60",
+            badgeBg: "",
         }
-        : {
-            iconBg: "bg-red-500/10",
-            iconColor: "text-red-500",
-            badgeBg: "bg-red-500 hover:bg-red-600"
-        };
+        : isOnline
+            ? {
+                iconBg: "bg-green-500/10",
+                iconColor: "text-green-500",
+                badgeBg: "bg-green-500 hover:bg-green-600"
+            }
+            : {
+                iconBg: "bg-red-500/10",
+                iconColor: "text-red-500",
+                badgeBg: "bg-red-500 hover:bg-red-600"
+            };
 
     return (
         <>
@@ -101,9 +107,13 @@ export function BotStats() {
                 </CardHeader>
                 <CardContent className="min-h-[84px]">
                     <div className="flex items-center gap-2">
-                        <Badge className={statusStyles.badgeBg}>
-                            {isLoading ? "..." : isOnline ? t("online") : t("offline") /* NOSONAR — JSX nested ternary for multi-branch display state */}
-                        </Badge>
+                        {isLoading ? (
+                            <Skeleton className="h-6 w-20 rounded-full animate-pulse" />
+                        ) : (
+                            <Badge className={statusStyles.badgeBg}>
+                                {isOnline ? t("online") : t("offline")}
+                            </Badge>
+                        )}
                     </div>
                     <div className="mt-2 min-h-[40px] space-y-1">
                         {isLoading ? (

--- a/components/dashboard/clans-summary.tsx
+++ b/components/dashboard/clans-summary.tsx
@@ -70,13 +70,28 @@ export function ClansSummary({ guildId }: ClansSummaryProps) {
   if (isLoading) {
     return (
       <Card className="bg-card border-border">
-        <CardHeader>
-          <Skeleton className="h-5 w-32" />
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle className="text-foreground">{t("clans.title")}</CardTitle>
+            <CardDescription className="flex h-5 items-center">
+              <Skeleton className="h-3.5 w-36" />
+            </CardDescription>
+          </div>
+          <Skeleton className="h-8 w-24" />
         </CardHeader>
         <CardContent>
-          <div className="flex gap-3 flex-wrap">
+          <div className="flex flex-wrap gap-3">
             {[1, 2, 3].map((i) => (
-              <Skeleton key={i} className="h-16 w-32 rounded-lg" />
+              <div
+                key={i}
+                className="flex h-[52px] w-[220px] items-center gap-2 rounded-lg border border-border bg-background px-3 py-2"
+              >
+                <Skeleton className="h-7 w-7 rounded-sm" />
+                <div className="space-y-1">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
             ))}
           </div>
         </CardContent>
@@ -139,7 +154,7 @@ export function ClansSummary({ guildId }: ClansSummaryProps) {
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
         <div>
           <CardTitle className="text-foreground">{t("clans.title")}</CardTitle>
-          <CardDescription>{t("clans.description", { count: clans.length })}</CardDescription>
+          <CardDescription className="flex h-5 items-center">{t("clans.description", { count: clans.length })}</CardDescription>
         </div>
         <Button
           variant="outline"
@@ -158,7 +173,7 @@ export function ClansSummary({ guildId }: ClansSummaryProps) {
             return (
               <div
                 key={tag}
-                className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2"
+                className="flex h-[52px] w-[220px] items-center gap-2 overflow-hidden rounded-lg border border-border bg-background px-3 py-2"
               >
                 <Image
                   src={badge}
@@ -168,9 +183,9 @@ export function ClansSummary({ guildId }: ClansSummaryProps) {
                   className="rounded-sm"
                   unoptimized
                 />
-                <div>
-                  <p className="text-sm font-medium text-foreground leading-tight">{name}</p>
-                  <p className="text-xs text-muted-foreground">{tag}</p>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium leading-tight text-foreground">{name}</p>
+                  <p className="truncate text-xs text-muted-foreground">{tag}</p>
                 </div>
               </div>
             );

--- a/components/dashboard/server-stats.tsx
+++ b/components/dashboard/server-stats.tsx
@@ -151,13 +151,15 @@ export function ServerStats({ guildId }: ServerStatsProps) {
             <div className="rounded-full bg-primary/10 p-2">{card.icon}</div>
           </CardHeader>
           <CardContent className="min-h-[84px]">
-            {isLoading ? (
-              <Skeleton className="h-8 w-20 animate-pulse mb-1" />
-            ) : (
-              <div className="text-2xl font-bold text-foreground">
-                {card.value.toLocaleString()}
-              </div>
-            )}
+            <div className="mb-1 flex h-8 items-center">
+              {isLoading ? (
+                <Skeleton className="h-8 w-20 animate-pulse" />
+              ) : (
+                <div className="text-2xl font-bold text-foreground">
+                  {card.value.toLocaleString()}
+                </div>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground">{card.desc}</p>
           </CardContent>
         </Card>

--- a/components/dashboard/sidebar-wrapper.tsx
+++ b/components/dashboard/sidebar-wrapper.tsx
@@ -28,8 +28,8 @@ function getStoredGuildInfo(guildId: string): CachedGuildInfo | null {
   try {
     const stored = sessionStorage.getItem("selected_guild");
     if (!stored) return null;
-    const parsed = JSON.parse(stored) as Partial<CachedGuildInfo>;
-    if (!parsed || parsed.id !== guildId || typeof parsed.name !== "string") {
+    const parsed = JSON.parse(stored) as Partial<CachedGuildInfo> | null;
+    if (parsed?.id !== guildId || typeof parsed?.name !== "string") {
       return null;
     }
     return {

--- a/components/dashboard/sidebar-wrapper.tsx
+++ b/components/dashboard/sidebar-wrapper.tsx
@@ -12,10 +12,34 @@ interface SidebarWrapperProps {
   readonly variant?: "sidebar" | "mobile-header";
 }
 
+interface CachedGuildInfo {
+  id: string;
+  name: string;
+  icon?: string;
+}
+
 const GUILD_INFO_CACHE_TTL = 120000;
 
 function getGuildInfoCacheKey(guildId: string): string {
   return `guild-info-${guildId}`;
+}
+
+function getStoredGuildInfo(guildId: string): CachedGuildInfo | null {
+  try {
+    const stored = sessionStorage.getItem("selected_guild");
+    if (!stored) return null;
+    const parsed = JSON.parse(stored) as Partial<CachedGuildInfo>;
+    if (!parsed || parsed.id !== guildId || typeof parsed.name !== "string") {
+      return null;
+    }
+    return {
+      id: parsed.id,
+      name: parsed.name,
+      icon: typeof parsed.icon === "string" ? parsed.icon : undefined,
+    };
+  } catch {
+    return null;
+  }
 }
 
 export function SidebarWrapper({ guildId, locale, variant = "sidebar" }: SidebarWrapperProps) {
@@ -28,6 +52,15 @@ export function SidebarWrapper({ guildId, locale, variant = "sidebar" }: Sidebar
   useEffect(() => {
     async function fetchServerInfo() {
       try {
+        const storedGuild = getStoredGuildInfo(guildId);
+        if (storedGuild) {
+          setServerInfo({
+            name: storedGuild.name,
+            icon: storedGuild.icon,
+          });
+          setIsLoading(false);
+        }
+
         const token = localStorage.getItem("access_token");
         if (!token) {
           setIsLoading(false);
@@ -57,6 +90,15 @@ export function SidebarWrapper({ guildId, locale, variant = "sidebar" }: Sidebar
           name: guild.name || "My Server",
           icon: iconUrl,
         });
+
+        sessionStorage.setItem(
+          "selected_guild",
+          JSON.stringify({
+            id: guildId,
+            name: guild.name || "My Server",
+            icon: iconUrl,
+          })
+        );
       } catch (error) {
         console.error("Failed to fetch server info:", { guildId, error });
       } finally {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2098,7 +2098,7 @@
   },
   "ServersPage": {
     "title": "Select a Server",
-    "description": "Choose a server to configure ClashKing bot settings",
+    "description": "Choose a server to configure ClashKing bot settings. You must be the Discord server owner or an administrator.",
     "backToHome": "Back to Home",
     "backToLogin": "Back to Login",
     "error": "Error",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2121,7 +2121,7 @@
   },
   "ServersPage": {
     "title": "Sélectionner un Serveur",
-    "description": "Choisissez un serveur pour configurer les paramètres du bot ClashKing",
+    "description": "Choisissez un serveur pour configurer les paramètres du bot ClashKing. Vous devez être le propriétaire ou un administrateur du serveur Discord.",
     "backToHome": "Retour à l'Accueil",
     "backToLogin": "Retour à la Connexion",
     "error": "Erreur",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -2101,7 +2101,7 @@
   },
   "ServersPage": {
     "title": "Selecteer een Server",
-    "description": "Kies een server om ClashKing bot instellingen te configureren",
+    "description": "Kies een server om ClashKing bot instellingen te configureren. Je moet de eigenaar of een beheerder van de Discord-server zijn.",
     "backToHome": "Terug naar Home",
     "backToLogin": "Terug naar Login",
     "error": "Fout",


### PR DESCRIPTION
Changes Included
Tickets:

- Improved loading state for ticket count/description display.

Panels:

- Refined channel-loading behavior with skeleton-first rendering.

Overview:

- Reduced subtle layout shifts in stats and “Your Clans” card rendering.
- Improved loading and loaded-state structural parity.

Family Settings:

- Stabilized skeleton/input/preview heights to prevent jumping.

Roles:

- Added stronger tab header consistency and count badge behavior.
- Added required-field indicators in the add dialog.
- Added duplicate-combination guard for role mappings.
- Fixed controlled/uncontrolled Select value behavior.
- Updated mobile tabs to stack vertically when space is limited.

Reminders:

- Improved tab header width and badge consistency.
- Updated mobile tabs to stack vertically when space is limited.

Giveaways:

- Improved tab badge styling/alignment for loading and loaded states.
- Updated mobile tabs to stack vertically when space is limited.

Sidebar/Servers:

- Added selected guild caching flow to improve initial sidebar server name/icon rendering.

i18n:

- Updated server-page description copy (en/fr/nl) to clarify owner/admin requirement.

Fixes #269, #268