### PR TITLE
feat: polish dashboard UX and improve locale behavior

### DIFF
--- a/app/[locale]/dashboard/[guildId]/bans-and-strikes/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/bans-and-strikes/page.tsx
@@ -768,7 +768,7 @@ export default function BansPage() { // NOSONAR — React page component: comple
             <Card className="bg-card border-border">
               <CardHeader>
                 <div className="flex flex-col xl:flex-row xl:items-center xl:justify-between gap-4">
-                  <div className="flex flex-col md:flex-row md:items-center gap-4">
+                  <div className="flex flex-col md:flex-row md:items-start gap-4">
                     <div>
                       <CardTitle>{t("bans.list.title")}</CardTitle>
                       <CardDescription>
@@ -1105,7 +1105,7 @@ export default function BansPage() { // NOSONAR — React page component: comple
               <Card className="bg-card border-border">
               <CardHeader>
                 <div className="flex flex-col xl:flex-row xl:items-center xl:justify-between gap-4">
-                  <div className="flex flex-col md:flex-row md:items-center gap-4">
+                  <div className="flex flex-col md:flex-row md:items-start gap-4">
                     <div>
                       <CardTitle>{t("strikes.list.title")}</CardTitle>
                       <CardDescription>

--- a/app/[locale]/dashboard/[guildId]/bans-and-strikes/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/bans-and-strikes/page.tsx
@@ -51,12 +51,19 @@ import {
   Users,
   ChevronRight,
   ChevronDown,
+  ChevronUp,
+  ChevronsUpDown,
 } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { apiClient } from "@/lib/api/client";
 import { apiCache } from "@/lib/api-cache";
 import type { BannedPlayer, Strike } from "@/lib/api/types/server";
 import { useToast } from "@/components/ui/use-toast";
+
+type SortDirection = "asc" | "desc";
+type BanSortKey = "player" | "reason" | "bannedBy" | "date";
+type StrikeSortKey = "player" | "reason" | "addedBy" | "date";
+type GroupedStrikeSortKey = "player" | "totalStrikes" | "totalWeight" | "lastStrike";
 
 export default function BansPage() { // NOSONAR — React page component: complexity is aggregate state/handler management, not a single logic unit
   const params = useParams();
@@ -93,6 +100,18 @@ export default function BansPage() { // NOSONAR — React page component: comple
   const [strikeViewMode, setStrikeViewMode] = useState<"grouped" | "all">("grouped");
   const [expandedPlayerTags, setExpandedPlayerTags] = useState<string[]>([]);
   const [clanNameByTag, setClanNameByTag] = useState<Record<string, string>>({});
+  const [banSort, setBanSort] = useState<{ key: BanSortKey; direction: SortDirection }>({
+    key: "date",
+    direction: "desc",
+  });
+  const [strikeSort, setStrikeSort] = useState<{ key: StrikeSortKey; direction: SortDirection }>({
+    key: "date",
+    direction: "desc",
+  });
+  const [groupedStrikeSort, setGroupedStrikeSort] = useState<{ key: GroupedStrikeSortKey; direction: SortDirection }>({
+    key: "totalWeight",
+    direction: "desc",
+  });
 
   // Fetch bans and strikes on mount
   useEffect(() => {
@@ -440,6 +459,116 @@ export default function BansPage() { // NOSONAR — React page component: comple
       strike.reason.toLowerCase().includes(searchQueryStrikes.toLowerCase())
   );
 
+  const toggleBanSort = (key: BanSortKey) => {
+    setBanSort((current) => {
+      if (current.key === key) {
+        return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+      }
+
+      return { key, direction: key === "date" ? "desc" : "asc" };
+    });
+  };
+
+  const toggleStrikeSort = (key: StrikeSortKey) => {
+    setStrikeSort((current) => {
+      if (current.key === key) {
+        return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+      }
+
+      return { key, direction: key === "date" ? "desc" : "asc" };
+    });
+  };
+
+  const toggleGroupedStrikeSort = (key: GroupedStrikeSortKey) => {
+    setGroupedStrikeSort((current) => {
+      if (current.key === key) {
+        return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+      }
+
+      return {
+        key,
+        direction: key === "lastStrike" || key === "totalWeight" ? "desc" : "asc",
+      };
+    });
+  };
+
+  const sortText = (left: string, right: string) =>
+    left.localeCompare(right, locale, { sensitivity: "base" });
+
+  const toTime = (value: string | null | undefined) => {
+    if (!value) return 0;
+    const parsed = new Date(value).getTime();
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  const sortedBans = [...filteredBans].sort((left, right) => {
+    let result = 0;
+
+    switch (banSort.key) {
+      case "player": {
+        const leftPlayer = left.VillageName || left.name || left.VillageTag || "";
+        const rightPlayer = right.VillageName || right.name || right.VillageTag || "";
+        result = sortText(leftPlayer, rightPlayer);
+        break;
+      }
+      case "reason": {
+        result = sortText(left.Notes || "", right.Notes || "");
+        break;
+      }
+      case "bannedBy": {
+        const leftAddedBy = left.added_by_username || String(left.added_by ?? "");
+        const rightAddedBy = right.added_by_username || String(right.added_by ?? "");
+        result = sortText(leftAddedBy, rightAddedBy);
+        break;
+      }
+      case "date":
+      default: {
+        result = toTime(left.DateCreated) - toTime(right.DateCreated);
+        break;
+      }
+    }
+
+    return banSort.direction === "asc" ? result : -result;
+  });
+
+  const sortedStrikes = [...filteredStrikes].sort((left, right) => {
+    let result = 0;
+
+    switch (strikeSort.key) {
+      case "player": {
+        result = sortText(left.player_name || left.tag || "", right.player_name || right.tag || "");
+        break;
+      }
+      case "reason": {
+        result = sortText(left.reason || "", right.reason || "");
+        break;
+      }
+      case "addedBy": {
+        const leftAddedBy = left.added_by_username || String(left.added_by ?? "");
+        const rightAddedBy = right.added_by_username || String(right.added_by ?? "");
+        result = sortText(leftAddedBy, rightAddedBy);
+        break;
+      }
+      case "date":
+      default: {
+        result = toTime(left.date_created) - toTime(right.date_created);
+        break;
+      }
+    }
+
+    return strikeSort.direction === "asc" ? result : -result;
+  });
+
+  const renderSortIcon = (isActive: boolean, direction: SortDirection) => {
+    if (!isActive) {
+      return <ChevronsUpDown className="h-3.5 w-3.5 opacity-40" />;
+    }
+
+    return direction === "asc"
+      ? <ChevronUp className="h-3.5 w-3.5" />
+      : <ChevronDown className="h-3.5 w-3.5" />;
+  };
+
   const groupedStrikes = Object.values(
     filteredStrikes.reduce((acc, strike) => {
       const tag = strike.tag;
@@ -474,7 +603,33 @@ export default function BansPage() { // NOSONAR — React page component: comple
       last_strike: string,
       strikes: Strike[]
     }>)
-  ).sort((a, b) => b.total_weight - a.total_weight);
+  );
+
+  const sortedGroupedStrikes = [...groupedStrikes].sort((left, right) => {
+    let result = 0;
+
+    switch (groupedStrikeSort.key) {
+      case "player": {
+        result = sortText(left.player_name || left.tag || "", right.player_name || right.tag || "");
+        break;
+      }
+      case "totalStrikes": {
+        result = left.count - right.count;
+        break;
+      }
+      case "totalWeight": {
+        result = left.total_weight - right.total_weight;
+        break;
+      }
+      case "lastStrike":
+      default: {
+        result = toTime(left.last_strike) - toTime(right.last_strike);
+        break;
+      }
+    }
+
+    return groupedStrikeSort.direction === "asc" ? result : -result;
+  });
 
   // Calculate strike statistics
   const totalStrikeWeight = strikes.reduce((sum, strike) => sum + strike.strike_weight, 0);
@@ -732,15 +887,51 @@ export default function BansPage() { // NOSONAR — React page component: comple
                       <Table>
                         <TableHeader>
                           <TableRow>
-                            <TableHead>{t("bans.table.player")}</TableHead>
-                            <TableHead>{t("bans.table.reason")}</TableHead>
-                            <TableHead>{t("bans.table.bannedBy")}</TableHead>
-                            <TableHead>{t("bans.table.date")}</TableHead>
+                            <TableHead>
+                              <button
+                                type="button"
+                                onClick={() => toggleBanSort("player")}
+                                className="flex items-center gap-1 transition-colors hover:text-foreground"
+                              >
+                                {t("bans.table.player")}
+                                {renderSortIcon(banSort.key === "player", banSort.direction)}
+                              </button>
+                            </TableHead>
+                            <TableHead>
+                              <button
+                                type="button"
+                                onClick={() => toggleBanSort("reason")}
+                                className="flex items-center gap-1 transition-colors hover:text-foreground"
+                              >
+                                {t("bans.table.reason")}
+                                {renderSortIcon(banSort.key === "reason", banSort.direction)}
+                              </button>
+                            </TableHead>
+                            <TableHead>
+                              <button
+                                type="button"
+                                onClick={() => toggleBanSort("bannedBy")}
+                                className="flex items-center gap-1 transition-colors hover:text-foreground"
+                              >
+                                {t("bans.table.bannedBy")}
+                                {renderSortIcon(banSort.key === "bannedBy", banSort.direction)}
+                              </button>
+                            </TableHead>
+                            <TableHead>
+                              <button
+                                type="button"
+                                onClick={() => toggleBanSort("date")}
+                                className="flex items-center gap-1 transition-colors hover:text-foreground"
+                              >
+                                {t("bans.table.date")}
+                                {renderSortIcon(banSort.key === "date", banSort.direction)}
+                              </button>
+                            </TableHead>
                             <TableHead className="text-right">{tCommon("actions")}</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
-                          {filteredBans.map((ban, index) => (
+                          {sortedBans.map((ban, index) => (
                             <TableRow key={`${ban.VillageTag}-${index}`}>
                               <TableCell>
                                 <PlayerProfilePopover
@@ -1095,17 +1286,53 @@ export default function BansPage() { // NOSONAR — React page component: comple
                         <Table>
                           <TableHeader>
                             <TableRow>
-                              <TableHead>{t("strikes.table.player")}</TableHead>
-                              <TableHead>{t("strikes.table.reason")}</TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleStrikeSort("player")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.player")}
+                                  {renderSortIcon(strikeSort.key === "player", strikeSort.direction)}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleStrikeSort("reason")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.reason")}
+                                  {renderSortIcon(strikeSort.key === "reason", strikeSort.direction)}
+                                </button>
+                              </TableHead>
                               <TableHead>{t("strikes.table.weight")}</TableHead>
-                              <TableHead>{t("strikes.table.addedBy")}</TableHead>
-                              <TableHead>{t("strikes.table.date")}</TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleStrikeSort("addedBy")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.addedBy")}
+                                  {renderSortIcon(strikeSort.key === "addedBy", strikeSort.direction)}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleStrikeSort("date")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.date")}
+                                  {renderSortIcon(strikeSort.key === "date", strikeSort.direction)}
+                                </button>
+                              </TableHead>
                               <TableHead>{t("strikes.table.expires")}</TableHead>
                               <TableHead className="text-right">{tCommon("actions")}</TableHead>
                             </TableRow>
                           </TableHeader>
                           <TableBody>
-                            {filteredStrikes.map((strike, index) => (
+                            {sortedStrikes.map((strike, index) => (
                               <TableRow key={`${strike.strike_id}-${index}`}>
                                 <TableCell>
                                   <PlayerProfilePopover
@@ -1176,15 +1403,51 @@ export default function BansPage() { // NOSONAR — React page component: comple
                         <Table>
                           <TableHeader>
                             <TableRow>
-                              <TableHead>{t("strikes.table.player")}</TableHead>
-                              <TableHead className="text-center">{t("strikes.table.totalStrikes")}</TableHead>
-                              <TableHead className="text-center">{t("strikes.table.totalWeight")}</TableHead>
-                              <TableHead>{t("strikes.table.lastStrike")}</TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleGroupedStrikeSort("player")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.player")}
+                                  {renderSortIcon(groupedStrikeSort.key === "player", groupedStrikeSort.direction)}
+                                </button>
+                              </TableHead>
+                              <TableHead className="text-center">
+                                <button
+                                  type="button"
+                                  onClick={() => toggleGroupedStrikeSort("totalStrikes")}
+                                  className="mx-auto flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.totalStrikes")}
+                                  {renderSortIcon(groupedStrikeSort.key === "totalStrikes", groupedStrikeSort.direction)}
+                                </button>
+                              </TableHead>
+                              <TableHead className="text-center">
+                                <button
+                                  type="button"
+                                  onClick={() => toggleGroupedStrikeSort("totalWeight")}
+                                  className="mx-auto flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.totalWeight")}
+                                  {renderSortIcon(groupedStrikeSort.key === "totalWeight", groupedStrikeSort.direction)}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleGroupedStrikeSort("lastStrike")}
+                                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                                >
+                                  {t("strikes.table.lastStrike")}
+                                  {renderSortIcon(groupedStrikeSort.key === "lastStrike", groupedStrikeSort.direction)}
+                                </button>
+                              </TableHead>
                               <TableHead className="text-right">{tCommon("actions")}</TableHead>
                             </TableRow>
                           </TableHeader>
                           <TableBody>
-                            {groupedStrikes.map((group, index) => {
+                            {sortedGroupedStrikes.map((group, index) => {
                               const isExpanded = expandedPlayerTags.includes(group.tag);
                               return (
                                 <Fragment key={`${group.tag}-${index}`}>

--- a/app/[locale]/dashboard/[guildId]/clans/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/clans/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { logout } from "@/lib/auth/logout";
@@ -17,7 +17,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger
 } from "@/components/ui/dialog";
 import {
   AlertDialog,
@@ -49,6 +48,8 @@ import {
   Loader2,
   AlertCircle,
   Save,
+  ArrowDown,
+  ArrowUp,
   ChevronDown,
   ChevronRight,
   Eye
@@ -129,6 +130,9 @@ function normalizeClansPayload(payload: unknown): Clan[] {
   return [];
 }
 
+type ClanSortField = "added" | "name" | "level" | "members";
+type SortDirection = "asc" | "desc";
+
 export default function ClansPage() {
   const params = useParams();
   const router = useRouter();
@@ -172,6 +176,8 @@ export default function ClansPage() {
   const [saving, setSaving] = useState(false);
   const [clanToDelete, setClanToDelete] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [clanSortField, setClanSortField] = useState<ClanSortField>("added");
+  const [clanSortDirection, setClanSortDirection] = useState<SortDirection>("asc");
 
   // Dialog states
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -188,7 +194,8 @@ export default function ClansPage() {
   }>({ war_score: null, war_timer: null });
   const [countdownLoading, setCountdownLoading] = useState<string | null>(null);
 
-  const clansCacheKey = `clans-${guildId}`;
+  const clansCacheKey = `dashboard-server-clans-${guildId}`;
+  const sortPreferenceStorageKey = `clans-sort-preference-${guildId}`;
   const channelsCacheKey = dashboardCacheKeys.channels(guildId);
   const rolesCacheKey = dashboardCacheKeys.discordRoles(guildId);
 
@@ -197,7 +204,7 @@ export default function ClansPage() {
       apiCache.invalidate(clansCacheKey);
     }
 
-    return apiCache.get(clansCacheKey, async () => {
+    const cachedOrFetched = await apiCache.get(clansCacheKey, async () => {
       const response = await fetch(`/api/v2/server/${guildId}/clans`, {
         headers: { Authorization: `Bearer ${accessToken}` }
       });
@@ -211,11 +218,14 @@ export default function ClansPage() {
       const payload = await response.json();
       return normalizeClansPayload(payload);
     });
+
+    // Normalize again to protect against stale cache entries written by older code paths.
+    return normalizeClansPayload(cachedOrFetched);
   };
 
   const refreshClans = async (accessToken: string) => {
     const clansData = await fetchClans(accessToken, true);
-    setClans(clansData);
+    setClans(normalizeClansPayload(clansData));
   };
 
   // Fetch data on mount
@@ -230,7 +240,7 @@ export default function ClansPage() {
         }
 
         const clansData = await fetchClans(accessToken);
-        setClans(clansData);
+          setClans(normalizeClansPayload(clansData));
 
         const [channelsResult, rolesResult] = await Promise.allSettled([
           apiCache.get(channelsCacheKey, async () => {
@@ -279,6 +289,42 @@ export default function ClansPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [guildId]);
+
+  useEffect(() => {
+    if (!guildId) return;
+
+    const storedPreference = localStorage.getItem(sortPreferenceStorageKey);
+    if (!storedPreference) return;
+
+    try {
+      const parsedPreference = JSON.parse(storedPreference) as {
+        field?: unknown;
+        direction?: unknown;
+      };
+
+      const isValidField = parsedPreference.field === "added"
+        || parsedPreference.field === "name"
+        || parsedPreference.field === "level"
+        || parsedPreference.field === "members";
+      const isValidDirection = parsedPreference.direction === "asc" || parsedPreference.direction === "desc";
+
+      if (isValidField && isValidDirection) {
+        setClanSortField(parsedPreference.field);
+        setClanSortDirection(parsedPreference.direction);
+      }
+    } catch {
+      localStorage.removeItem(sortPreferenceStorageKey);
+    }
+  }, [guildId, sortPreferenceStorageKey]);
+
+  useEffect(() => {
+    if (!guildId) return;
+
+    localStorage.setItem(
+      sortPreferenceStorageKey,
+      JSON.stringify({ field: clanSortField, direction: clanSortDirection }),
+    );
+  }, [clanSortDirection, clanSortField, guildId, sortPreferenceStorageKey]);
 
   // Add clan
   const handleAddClan = async () => {
@@ -508,6 +554,35 @@ export default function ClansPage() {
     );
   }
 
+  const sortedClans = useMemo(() => {
+    const clansToSort = [...clans];
+    const directionMultiplier = clanSortDirection === "asc" ? 1 : -1;
+
+    const clanOrderByTag = new Map(clans.map((clan, index) => [clan.tag || clan.clan_tag || String(index), index]));
+    const getClanName = (clan: Clan) => (clan.name || clan.clan_name || "").toLowerCase();
+    const getClanLevel = (clan: Clan) => clan.level ?? clan.clanLevel ?? 0;
+    const getClanMembers = (clan: Clan) => clan.member_count ?? clan.members ?? 0;
+    const getClanOrder = (clan: Clan) => clanOrderByTag.get(clan.tag || clan.clan_tag || "") ?? Number.MAX_SAFE_INTEGER;
+
+    clansToSort.sort((a, b) => {
+      if (clanSortField === "added") {
+        return (getClanOrder(a) - getClanOrder(b)) * directionMultiplier;
+      }
+
+      if (clanSortField === "name") {
+        return getClanName(a).localeCompare(getClanName(b)) * directionMultiplier;
+      }
+
+      if (clanSortField === "level") {
+        return (getClanLevel(a) - getClanLevel(b)) * directionMultiplier;
+      }
+
+      return (getClanMembers(a) - getClanMembers(b)) * directionMultiplier;
+    });
+
+    return clansToSort;
+  }, [clanSortDirection, clanSortField, clans]);
+
   const totalMembers = clans.reduce((sum, clan) => sum + (clan.member_count || clan.members || 0), 0);
   const configuredClans = clans.filter(c =>
     c.settings?.clanChannel || c.settings?.generalRole
@@ -532,12 +607,6 @@ export default function ClansPage() {
 
           {/* Add Clan Dialog */}
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-            <DialogTrigger asChild>
-              <Button className="bg-primary hover:bg-primary/90 gap-2">
-                <Plus className="h-4 w-4" />
-                {t("addClan")}
-              </Button>
-            </DialogTrigger>
             <DialogContent className="bg-card border-border max-w-2xl">
               <DialogHeader>
                 <DialogTitle>{t("addNewClan")}</DialogTitle>
@@ -653,6 +722,54 @@ export default function ClansPage() {
           </Card>
         </div>
 
+        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          {(loading || clans.length > 0) && (
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Label className="text-sm text-muted-foreground">{t("sorting.label")}</Label>
+              {loading ? (
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-9 w-9 animate-pulse" />
+                  <Skeleton className="h-9 w-[220px] animate-pulse" />
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-9 w-9"
+                    aria-label={t("sorting.toggleDirection")}
+                    onClick={() => setClanSortDirection((current) => (current === "asc" ? "desc" : "asc"))}
+                  >
+                    {clanSortDirection === "asc" ? (
+                      <ArrowUp className="h-4 w-4" />
+                    ) : (
+                      <ArrowDown className="h-4 w-4" />
+                    )}
+                  </Button>
+                  <Select value={clanSortField} onValueChange={(value) => setClanSortField(value as ClanSortField)}>
+                    <SelectTrigger className="w-full min-w-[220px] border-border bg-background sm:w-[220px]">
+                      <SelectValue placeholder={t("sorting.sortBy")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="added">{t("sorting.added")}</SelectItem>
+                      <SelectItem value="name">
+                        {t("sorting.name")}
+                      </SelectItem>
+                      <SelectItem value="level">{t("sorting.level")}</SelectItem>
+                      <SelectItem value="members">{t("sorting.members")}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
+
+          <Button onClick={() => setIsAddDialogOpen(true)} className="w-full gap-2 bg-primary hover:bg-primary/90 md:w-auto">
+            <Plus className="h-4 w-4" />
+            {t("addClan")}
+          </Button>
+        </div>
+
         {/* Clans Grid */}
         {loading ? (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -709,7 +826,7 @@ export default function ClansPage() {
           </Card>
         ) : (
           <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-            {clans.map((clan) => {
+            {sortedClans.map((clan) => {
               const isConfigured = !!(clan.settings?.clanChannel || clan.settings?.generalRole);
 
               return (

--- a/app/[locale]/dashboard/[guildId]/clans/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/clans/page.tsx
@@ -309,8 +309,8 @@ export default function ClansPage() {
       const isValidDirection = parsedPreference.direction === "asc" || parsedPreference.direction === "desc";
 
       if (isValidField && isValidDirection) {
-        setClanSortField(parsedPreference.field);
-        setClanSortDirection(parsedPreference.direction);
+        setClanSortField(parsedPreference.field as ClanSortField);
+        setClanSortDirection(parsedPreference.direction as SortDirection);
       }
     } catch {
       localStorage.removeItem(sortPreferenceStorageKey);
@@ -533,27 +533,6 @@ export default function ClansPage() {
     }
   };
 
-  if (error) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-6">
-        <Card className="max-w-md border-destructive">
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <AlertCircle className="h-5 w-5 text-destructive" />
-              <CardTitle className="text-destructive">{tCommon("error")}</CardTitle>
-            </div>
-            <CardDescription>{error}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={() => globalThis.window.location.reload()} className="w-full">
-              {tCommon("retry")}
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   const sortedClans = useMemo(() => {
     const clansToSort = [...clans];
     const directionMultiplier = clanSortDirection === "asc" ? 1 : -1;
@@ -587,6 +566,27 @@ export default function ClansPage() {
   const configuredClans = clans.filter(c =>
     c.settings?.clanChannel || c.settings?.generalRole
   ).length;
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <Card className="max-w-md border-destructive">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <AlertCircle className="h-5 w-5 text-destructive" />
+              <CardTitle className="text-destructive">{tCommon("error")}</CardTitle>
+            </div>
+            <CardDescription>{error}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => globalThis.window.location.reload()} className="w-full">
+              {tCommon("retry")}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background p-4 md:p-6">

--- a/app/[locale]/dashboard/[guildId]/links/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/links/page.tsx
@@ -465,28 +465,31 @@ export default function LinksManagementPage() { // NOSONAR — complexity comes 
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="overview" className="w-full">
-            <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 h-auto">
-              <TabsTrigger value="overview">
-                <Users className="h-4 w-4 mr-2" />
-                Overview
+            <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-2 lg:grid-cols-4 sm:gap-0">
+              <TabsTrigger value="overview" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Users className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+                <span className="truncate">Overview</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-blue-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : membersWithLinks}
+                </span>
               </TabsTrigger>
-              <TabsTrigger value="pending">
-                <Clock className="h-4 w-4 mr-2" />
-                Pending{" ("}
-                {loading ? (
-                  <span className="inline-block h-3 w-6 align-middle rounded bg-muted animate-pulse" />
-                ) : (
-                  pendingVerifications.length
-                )}
-                {")"}
+              <TabsTrigger value="pending" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Clock className="h-3.5 w-3.5 shrink-0 text-yellow-500" />
+                <span className="truncate">Pending</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-yellow-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : pendingVerifications.length}
+                </span>
               </TabsTrigger>
-              <TabsTrigger value="bulk">
-                <Settings className="h-4 w-4 mr-2" />
-                Bulk Actions
+              <TabsTrigger value="bulk" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <Settings className="h-3.5 w-3.5 shrink-0 text-purple-500" />
+                <span className="truncate">Bulk Actions</span>
               </TabsTrigger>
-              <TabsTrigger value="analytics">
-                <BarChart3 className="h-4 w-4 mr-2" />
-                Analytics
+              <TabsTrigger value="analytics" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+                <BarChart3 className="h-3.5 w-3.5 shrink-0 text-green-500" />
+                <span className="truncate">Analytics</span>
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-green-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                  {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : totalLinkedAccounts}
+                </span>
               </TabsTrigger>
             </TabsList>
 

--- a/app/[locale]/dashboard/[guildId]/logs/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/logs/page.tsx
@@ -423,6 +423,18 @@ export default function LogsPage() {
     }).length;
   };
 
+  const countActiveLogsByDefinitions = (logDefinitions: LogTypeDefinition[]) => {
+    const currentClan = getCurrentClan();
+    if (!currentClan) return 0;
+
+    return logDefinitions.filter((definition) => {
+      return definition.keys.some((key) => {
+        const config = currentClan[key as keyof ClanLogsConfig];
+        return Boolean(config && typeof config === 'object' && config.webhook);
+      });
+    }).length;
+  };
+
 
   // Separate component for LogCard to use hooks properly
   const LogCard = ({ logDef, statusLoading = false }: { logDef: LogTypeDefinition; statusLoading?: boolean }) => { // NOSONAR — inline sub-component uses parent closures; complexity is structural JSX, not logic
@@ -777,22 +789,34 @@ export default function LogsPage() {
         )}
 
         <Tabs defaultValue="clan" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 lg:w-[800px] bg-secondary h-auto p-1">
-            <TabsTrigger value="clan" className="data-[state=active]:bg-background">
-              <Users className="mr-2 h-4 w-4" />
-              {t('tabs.clan')}
+          <TabsList className="grid h-auto w-full grid-cols-1 gap-1 rounded-lg border border-border bg-muted p-1 sm:grid-cols-2 lg:grid-cols-4 sm:gap-0">
+            <TabsTrigger value="clan" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+              <Users className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+              <span className="truncate">{t('tabs.clan')}</span>
+              <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-blue-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : countActiveLogsByDefinitions(CLAN_LOGS)}
+              </span>
             </TabsTrigger>
-            <TabsTrigger value="war" className="data-[state=active]:bg-background">
-              <Swords className="mr-2 h-4 w-4" />
-              {t('tabs.war')}
+            <TabsTrigger value="war" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+              <Swords className="h-3.5 w-3.5 shrink-0 text-red-500" />
+              <span className="truncate">{t('tabs.war')}</span>
+              <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-red-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : countActiveLogsByDefinitions(WAR_LOGS)}
+              </span>
             </TabsTrigger>
-            <TabsTrigger value="capital" className="data-[state=active]:bg-background">
-              <Castle className="mr-2 h-4 w-4" />
-              {t('tabs.capital')}
+            <TabsTrigger value="capital" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+              <Castle className="h-3.5 w-3.5 shrink-0 text-purple-500" />
+              <span className="truncate">{t('tabs.capital')}</span>
+              <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-purple-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : countActiveLogsByDefinitions(CAPITAL_LOGS)}
+              </span>
             </TabsTrigger>
-            <TabsTrigger value="player" className="data-[state=active]:bg-background">
-              <TrendingUp className="mr-2 h-4 w-4" />
-              {t('tabs.player')}
+            <TabsTrigger value="player" className="h-9 justify-center gap-2 px-3 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm sm:text-sm">
+              <TrendingUp className="h-3.5 w-3.5 shrink-0 text-orange-500" />
+              <span className="truncate">{t('tabs.player')}</span>
+              <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[4px] bg-orange-600 px-1 text-[11px] font-semibold leading-none text-white shadow-sm">
+                {loading ? <Skeleton className="h-2.5 w-2.5 rounded-[2px]" /> : countActiveLogsByDefinitions(PLAYER_LOGS)}
+              </span>
             </TabsTrigger>
           </TabsList>
 

--- a/app/[locale]/dashboard/[guildId]/reminders/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/reminders/page.tsx
@@ -192,15 +192,23 @@ export default function RemindersPage() { // NOSONAR — React page component: c
           throw new Error("API URL is not configured");
         }
 
-        // Fetch clans, channels, and reminders in parallel
-        const [clansRes, channelsRes, remindersRes] = await Promise.all([
-          apiCache.get(clansCacheKey, async () => {
+        const clansPromise = apiCache
+          .get(clansCacheKey, async () => {
             const response = await apiClient.servers.getServerClans(guildId);
             if (response.error) {
               throw new Error(response.error || 'Failed to fetch clans');
             }
             return response.data ?? [];
-          }),
+          })
+          .catch((clanError) => {
+            // Keep reminders usable even if clan metadata is temporarily unavailable.
+            console.warn("Failed to fetch clans for reminders page:", clanError);
+            return [] as Clan[];
+          });
+
+        // Fetch clans, channels, and reminders in parallel
+        const [clansRes, channelsRes, remindersRes] = await Promise.all([
+          clansPromise,
           apiCache.get(channelsCacheKey, async () => {
             const res = await fetch(`/api/v2/server/${guildId}/channels`, {
               headers: {

--- a/app/[locale]/dashboard/[guildId]/reminders/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/reminders/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { logout } from "@/lib/auth/logout";
 import { useTranslations } from "next-intl";
 import { apiCache } from "@/lib/api-cache";
+import { apiClient } from "@/lib/api/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -14,6 +15,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ChannelCombobox } from "@/components/ui/channel-combobox";
+import { DiscordOpenPopover } from "@/components/ui/discord-open-popover";
+import { ClanProfilePopover } from "@/components/ui/clan-profile-popover";
 import {
   Dialog,
   DialogContent,
@@ -82,6 +85,9 @@ interface CreateReminderRequest {
 interface Clan {
   tag: string;
   name: string;
+  badge_url?: string | null;
+  clan_badge_url?: string | null;
+  badge?: string | null;
 }
 
 interface Channel {
@@ -130,6 +136,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
   const { toast } = useToast();
   const guildId = params.guildId as string;
   const t = useTranslations("RemindersPage");
+  const tCommon = useTranslations("Common");
   const reminderTypes = [
     { value: "War", label: t('types.war'), icon: Target, color: "text-red-500", tabIcon: Target },
     { value: "Clan Capital", label: t('types.capital'), icon: Castle, color: "text-purple-500", tabIcon: Castle },
@@ -152,6 +159,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
   const [activeTab, setActiveTab] = useState<string>("war");
   const newReminderRef = useRef<HTMLDivElement>(null);
   const channelsCacheKey = `reminders-channels-${guildId}`;
+  const clansCacheKey = `reminders-clans-${guildId}`;
 
   // Dialog state
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -177,11 +185,12 @@ export default function RemindersPage() { // NOSONAR — React page component: c
 
         // Fetch clans, channels, and reminders in parallel
         const [clansRes, channelsRes, remindersRes] = await Promise.all([
-          fetch(`/api/v2/server/${guildId}/clans-basic`, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'Content-Type': 'application/json',
-            },
+          apiCache.get(clansCacheKey, async () => {
+            const response = await apiClient.servers.getServerClans(guildId);
+            if (response.error) {
+              throw new Error(response.error || 'Failed to fetch clans');
+            }
+            return response.data ?? [];
           }),
           apiCache.get(channelsCacheKey, async () => {
             const res = await fetch(`/api/v2/server/${guildId}/channels`, {
@@ -211,10 +220,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
         }
 
         // Parse clans
-        if (clansRes.ok) {
-          const clansData = await clansRes.json();
-          setClans(clansData || []);
-        }
+        setClans(clansRes || []);
 
         // Parse channels
         setChannels(normalizeChannelsPayload(channelsRes));
@@ -243,7 +249,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
     if (guildId) {
       fetchReminders();
     }
-  }, [channelsCacheKey, guildId, router, toast]);
+  }, [channelsCacheKey, clansCacheKey, guildId, router, toast]);
 
   // Get reminders for current tab
   const getCurrentReminders = (): ReminderConfig[] => {
@@ -773,29 +779,38 @@ export default function RemindersPage() { // NOSONAR — React page component: c
           </div>
 
           {/* Clan Selector and Add Button */}
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4 mb-4">
-            <Button onClick={addReminder} className="gap-2 w-full md:w-auto">
-              <Plus className="h-4 w-4" />
-              {t('actions.addReminder')}
-            </Button>
-            {clans.length > 0 && (
-                <div className="flex items-center gap-2 w-full md:w-auto">
-                  <Label className="text-sm text-muted-foreground whitespace-nowrap">{t('clanSelector.label')}</Label>
-                  <Select value={selectedClan} onValueChange={setSelectedClan}>
-                    <SelectTrigger className="w-full md:w-[250px]">
-                      <SelectValue placeholder={t('clanSelector.placeholder')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">{t('clanSelector.allClans')}</SelectItem>
-                      {clans.map((clan) => (
+          <div className="mb-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            {(loading || clans.length > 0) && (
+              <div className="flex w-full items-center gap-2 md:w-auto">
+                {loading ? (
+                  <>
+                    <Skeleton className="h-3.5 w-24" />
+                    <Skeleton className="h-9 w-full md:w-[250px]" />
+                  </>
+                ) : (
+                  <>
+                    <Label className="whitespace-nowrap text-sm text-muted-foreground">{t('clanSelector.label')}</Label>
+                    <Select value={selectedClan} onValueChange={setSelectedClan}>
+                      <SelectTrigger className="w-full md:w-[250px]">
+                        <SelectValue placeholder={t('clanSelector.placeholder')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">{t('clanSelector.allClans')}</SelectItem>
+                        {clans.map((clan) => (
                           <SelectItem key={clan.tag} value={clan.tag}>
                             {clan.name} ({clan.tag})
                           </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </>
+                )}
+              </div>
             )}
+            <Button onClick={addReminder} className="w-full gap-2 md:w-auto md:shrink-0">
+              <Plus className="h-4 w-4" />
+              {t('actions.addReminder')}
+            </Button>
           </div>
 
           {/* Tabs */}
@@ -890,8 +905,14 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                           const isNew = reminder.id.startsWith('temp-');
                           const typeInfo = reminderTypes.find(t => t.value === reminder.type);
                           const TypeIcon = typeInfo?.icon || Bell;
-                          const channelName = channels.find(c => c.id === reminder.channel_id)?.name;
-                          const clanName = clans.find(c => c.tag === reminder.clan_tag)?.name;
+                          const selectedChannel = channels.find(c => c.id === reminder.channel_id);
+                          const channelLabel = selectedChannel
+                            ? selectedChannel.parent_name
+                              ? `${selectedChannel.parent_name} / #${selectedChannel.name}`
+                              : `#${selectedChannel.name}`
+                            : null;
+                          const clan = clans.find(c => c.tag === reminder.clan_tag);
+                          const clanName = clan?.name;
 
                           return (
                               <Card
@@ -942,13 +963,55 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                                 <CardContent className="space-y-4">
                                   <div className="grid gap-4 md:grid-cols-2">
                                     <div className="space-y-1">
-                                      <Label className="text-sm text-muted-foreground">{t('card.channel')}</Label>
-                                      <p className="text-sm font-medium">{channelName || reminder.channel_id || t('card.notSet')}</p>
+                                      <Label className="block text-sm text-muted-foreground">{t('card.channel')}</Label>
+                                      <div className="pt-0.5">
+                                        {channelLabel && reminder.channel_id ? (
+                                          <DiscordOpenPopover
+                                            title={channelLabel}
+                                            description={t('card.channel')}
+                                            url={`https://discord.com/channels/${guildId}/${reminder.channel_id}`}
+                                            buttonLabel={tCommon('openChannelInDiscord')}
+                                            trigger={(
+                                              <button
+                                                type="button"
+                                                className="max-w-full truncate text-left text-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-primary hover:underline"
+                                              >
+                                                {channelLabel}
+                                              </button>
+                                            )}
+                                          />
+                                        ) : reminder.channel_id ? (
+                                          <span className="text-sm font-medium text-orange-500">{reminder.channel_id}</span>
+                                        ) : (
+                                          <span className="text-sm font-medium text-muted-foreground">{t('card.notSet')}</span>
+                                        )}
+                                      </div>
                                     </div>
 
                                     <div className="space-y-1">
-                                      <Label className="text-sm text-muted-foreground">{t('card.clan')}</Label>
-                                      <p className="text-sm font-medium">{clanName ? `${clanName} (${reminder.clan_tag})` : reminder.clan_tag || t('card.notSet')}</p>
+                                      <Label className="block text-sm text-muted-foreground">{t('card.clan')}</Label>
+                                      <div className="pt-0.5">
+                                        {reminder.clan_tag ? (
+                                          <ClanProfilePopover
+                                            clanName={clanName || reminder.clan_tag}
+                                            clanTag={reminder.clan_tag}
+                                            clanBadgeUrl={
+                                              clan?.badge_url
+                                              ?? clan?.clan_badge_url
+                                              ?? clan?.badge
+                                              ?? null
+                                            }
+                                            showTagInTrigger={false}
+                                            triggerClassName="text-left cursor-pointer transition-opacity hover:opacity-80"
+                                          >
+                                            <span className="text-sm font-medium text-foreground underline-offset-2 hover:underline">
+                                              {clanName ? `${clanName} (${reminder.clan_tag})` : reminder.clan_tag}
+                                            </span>
+                                          </ClanProfilePopover>
+                                        ) : (
+                                          <span className="text-sm font-medium text-muted-foreground">{t('card.notSet')}</span>
+                                        )}
+                                      </div>
                                     </div>
                                   </div>
 

--- a/app/[locale]/dashboard/[guildId]/reminders/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/reminders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { logout } from "@/lib/auth/logout";
 import { useTranslations } from "next-intl";
@@ -125,6 +125,15 @@ const TYPE_TIME_LIMIT: Record<string, number> = {
   "Clan Games": 336,
   "Clan Capital": 168,
 };
+
+function formatChannelLabel(channel: Channel | undefined): string | null {
+  if (!channel) return null;
+  if (channel.parent_name) {
+    return `${channel.parent_name} / #${channel.name}`;
+  }
+
+  return `#${channel.name}`;
+}
 
 function getTimeLimit(type: string | undefined): number {
   return TYPE_TIME_LIMIT[type ?? ""] ?? 24;
@@ -289,6 +298,13 @@ export default function RemindersPage() { // NOSONAR — React page component: c
     });
 
     return sorted;
+  };
+
+  const getEmptyStateTitle = (tab: string): string => {
+    if (tab === "war") return t('empty.noWarReminders');
+    if (tab === "capital") return t('empty.noCapitalReminders');
+    if (tab === "games") return t('empty.noClanGamesReminders');
+    return t('empty.noInactivityReminders');
   };
 
   // Add a new reminder
@@ -888,7 +904,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                         <CardContent className="py-12 text-center">
                           <Bell className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                           <h3 className="text-lg font-semibold text-foreground mb-2">
-                            {tab === "war" ? t('empty.noWarReminders') : tab === "capital" ? t('empty.noCapitalReminders') : tab === "games" ? t('empty.noClanGamesReminders') : t('empty.noInactivityReminders') /* NOSONAR — JSX nested ternary for multi-branch display state */}
+                            {getEmptyStateTitle(tab)}
                           </h3>
                           <p className="text-muted-foreground mb-4">
                             {t('empty.getStarted')}
@@ -906,13 +922,33 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                           const typeInfo = reminderTypes.find(t => t.value === reminder.type);
                           const TypeIcon = typeInfo?.icon || Bell;
                           const selectedChannel = channels.find(c => c.id === reminder.channel_id);
-                          const channelLabel = selectedChannel
-                            ? selectedChannel.parent_name
-                              ? `${selectedChannel.parent_name} / #${selectedChannel.name}`
-                              : `#${selectedChannel.name}`
-                            : null;
+                          const channelLabel = formatChannelLabel(selectedChannel);
                           const clan = clans.find(c => c.tag === reminder.clan_tag);
                           const clanName = clan?.name;
+
+                          let channelValueNode: ReactNode;
+                          if (channelLabel && reminder.channel_id) {
+                            channelValueNode = (
+                              <DiscordOpenPopover
+                                title={channelLabel}
+                                description={t('card.channel')}
+                                url={`https://discord.com/channels/${guildId}/${reminder.channel_id}`}
+                                buttonLabel={tCommon('openChannelInDiscord')}
+                                trigger={(
+                                  <button
+                                    type="button"
+                                    className="max-w-full truncate text-left text-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-primary hover:underline"
+                                  >
+                                    {channelLabel}
+                                  </button>
+                                )}
+                              />
+                            );
+                          } else if (reminder.channel_id) {
+                            channelValueNode = <span className="text-sm font-medium text-orange-500">{reminder.channel_id}</span>;
+                          } else {
+                            channelValueNode = <span className="text-sm font-medium text-muted-foreground">{t('card.notSet')}</span>;
+                          }
 
                           return (
                               <Card
@@ -965,26 +1001,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                                     <div className="space-y-1">
                                       <Label className="block text-sm text-muted-foreground">{t('card.channel')}</Label>
                                       <div className="pt-0.5">
-                                        {channelLabel && reminder.channel_id ? (
-                                          <DiscordOpenPopover
-                                            title={channelLabel}
-                                            description={t('card.channel')}
-                                            url={`https://discord.com/channels/${guildId}/${reminder.channel_id}`}
-                                            buttonLabel={tCommon('openChannelInDiscord')}
-                                            trigger={(
-                                              <button
-                                                type="button"
-                                                className="max-w-full truncate text-left text-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-primary hover:underline"
-                                              >
-                                                {channelLabel}
-                                              </button>
-                                            )}
-                                          />
-                                        ) : reminder.channel_id ? (
-                                          <span className="text-sm font-medium text-orange-500">{reminder.channel_id}</span>
-                                        ) : (
-                                          <span className="text-sm font-medium text-muted-foreground">{t('card.notSet')}</span>
-                                        )}
+                                        {channelValueNode}
                                       </div>
                                     </div>
 

--- a/components/settings-dropdown.tsx
+++ b/components/settings-dropdown.tsx
@@ -22,8 +22,15 @@ import {
   LOCALE_MODE_COOKIE,
   getLocaleModeFromCookie,
   resolveBrowserLocale,
+  type SupportedLocale,
   type LocaleMode,
 } from "@/lib/locale-preference";
+
+const BROWSER_LANGUAGE_LABEL_BY_LOCALE: Record<SupportedLocale, string> = {
+  en: "Browser Language",
+  fr: "Langue du navigateur",
+  nl: "Browsertaal",
+};
 
 interface SettingsDropdownProps {
   locale: string;
@@ -74,8 +81,10 @@ export function SettingsDropdown({
     router.refresh();
   };
 
+  const browserLocale = mounted ? resolveBrowserLocale(navigator.languages) : "en";
+  const browserLanguageLabel = BROWSER_LANGUAGE_LABEL_BY_LOCALE[browserLocale];
   const currentLocale = mounted && localeMode === "browser"
-    ? resolveBrowserLocale(navigator.languages)
+    ? browserLocale
     : locale;
   const currentLanguage = LANGUAGE_OPTIONS.find((lang) => lang.code === currentLocale) ?? LANGUAGE_OPTIONS[0];
   let themeIcon = <Computer className="h-4 w-4" />;
@@ -143,7 +152,7 @@ export function SettingsDropdown({
               className={cn(itemClassName, localeMode === "browser" && selectedItemClassName)}
             >
               <Globe className="h-4 w-4" />
-              <span className={textClassName}>{t("browserLanguage")}</span>
+              <span className={textClassName}>{browserLanguageLabel}</span>
             </DropdownMenuItem>
             {LANGUAGE_OPTIONS.map((lang) => (
               <DropdownMenuItem

--- a/messages/en.json
+++ b/messages/en.json
@@ -1265,6 +1265,15 @@
     "configuredBadge": "Configured",
     "setupRequired": "Setup Required",
     "configure": "Configure",
+    "sorting": {
+      "label": "Sort clans",
+      "sortBy": "Sort by",
+      "toggleDirection": "Toggle sort direction",
+      "added": "Added on",
+      "name": "Clan name",
+      "level": "Clan level",
+      "members": "Members"
+    },
     "configureClan": "Configure {name} ({tag})",
     "customizeIntegration": "Customize Discord integration settings for this clan",
     "tabs": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1288,6 +1288,15 @@
     "configuredBadge": "Configuré",
     "setupRequired": "Configuration Requise",
     "configure": "Configurer",
+    "sorting": {
+      "label": "Trier les clans",
+      "sortBy": "Trier par",
+      "toggleDirection": "Inverser le sens du tri",
+      "added": "Ajouté le",
+      "name": "Nom du clan",
+      "level": "Niveau du clan",
+      "members": "Membres"
+    },
     "configureClan": "Configurer {name} ({tag})",
     "customizeIntegration": "Personnalisez les paramètres d'intégration Discord pour ce clan",
     "tabs": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1268,6 +1268,15 @@
     "configuredBadge": "Geconfigureerd",
     "setupRequired": "Configuratie Vereist",
     "configure": "Configureren",
+    "sorting": {
+      "label": "Sorteer clans",
+      "sortBy": "Sorteer op",
+      "toggleDirection": "Wissel sorteerrichting",
+      "added": "Toegevoegd op",
+      "name": "Clannaam",
+      "level": "Clanniveau",
+      "members": "Leden"
+    },
     "configureClan": "Configureer {name} ({tag})",
     "customizeIntegration": "Pas Discord-integratie-instellingen aan voor deze clan",
     "tabs": {


### PR DESCRIPTION
Summary
This PR delivers a UI/UX polish pass across multiple dashboard pages and fixes language-label behavior in settings.

What changed

- Restyled dashboard tab headers to align visual patterns across pages.
- Updated logs tab counters to show active/enabled logs instead of available definitions.
- Improved bans and strikes sorting, including grouped strike sorting and consistent sort UI behavior.
- Updated reminders controls layout and moved/additionally aligned loading skeletons.
- Added clickable channel and clan interactions in reminders with popover behavior.
- Removed the bulk counter badge from the Links tab header.
- Fixed clans runtime issue where clans data could resolve to a non-array shape from cache.
- Added clans sorting options and made sorting persistent via local storage.
- Added Added on as a sorting option and made it the default behavior for clans.
- Removed the double-arrow icon from the first clans sort option.
- Moved Add Clan action under the stats cards and placed sorting controls to the left.
- Updated browser-language menu behavior so the Browser language label is shown in the browser locale language (with English fallback for unsupported locales).