### PR TITLE
fix: standardize container widths for panels and embeds

### DIFF
--- a/app/[locale]/dashboard/[guildId]/embeds/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/embeds/page.tsx
@@ -159,21 +159,20 @@ export default function EmbedsPage() {
 
   return (
     <div className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">
-      <div className="mx-auto max-w-7xl space-y-6">
+      <div className="mx-auto max-w-4xl space-y-6">
         {/* Header */}
-        <div className="flex items-start gap-3">
-          <div className="rounded-lg border border-primary/20 bg-primary/10 p-3">
-            <FileText className="h-8 w-8 text-primary" />
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
+          <div className="flex items-start gap-3">
+            <div className="rounded-lg border border-primary/20 bg-primary/10 p-3">
+              <FileText className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-foreground md:text-3xl">{tPage("title")}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{tPage("description")}</p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-2xl font-bold text-foreground md:text-3xl">{tPage("title")}</h1>
-            <p className="mt-1 text-sm text-muted-foreground">{tPage("description")}</p>
-          </div>
-        </div>
-
-        {/* Actions bar */}
-        <div className="flex justify-end">
-          <Button onClick={openCreate}>
+          {/* Actions bar */}
+          <Button onClick={openCreate} className="w-full md:w-auto">
             <Plus className="mr-1.5 h-4 w-4" />{t("newEmbed")}
           </Button>
         </div>

--- a/app/[locale]/dashboard/[guildId]/embeds/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/embeds/page.tsx
@@ -159,7 +159,7 @@ export default function EmbedsPage() {
 
   return (
     <div className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
         {/* Header */}
         <div className="flex items-start gap-3">
           <div className="rounded-lg border border-primary/20 bg-primary/10 p-3">

--- a/app/[locale]/dashboard/[guildId]/panels/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/panels/page.tsx
@@ -440,7 +440,7 @@ export default function PanelsPage() {
 
   return (
     <div className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">
-      <div className="mx-auto max-w-6xl space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
         {/* Header */}
         <div className="flex items-start gap-3">
           <div className="flex items-start gap-3">


### PR DESCRIPTION
### Description
This PR standardizes the page container widths for the Panels and Embeds pages to improve layout consistency across the dashboard.

### Changes Made
Most dashboard pages already use max-w-7xl, so this update aligns these pages with the existing layout pattern.
- Embeds container width: `max-w-3xl` to `max-w-7xl`
- Panels container width: `max-w-6xl` to `max-w-7l`

#### Before
<img width="1730" height="296" alt="Before" src="https://github.com/user-attachments/assets/b1cdebd2-5bf4-46f5-90d0-7097dbd5d387" />


#### After
<img width="1638" height="270" alt="After" src="https://github.com/user-attachments/assets/86b3ea39-ea23-45f8-9b0d-f99367c0f0a2" />
