### PR TITLE
Limit large clan dropdown height

### DIFF
--- a/app/[locale]/dashboard/[guildId]/logs/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/logs/page.tsx
@@ -775,7 +775,7 @@ export default function LogsPage() {
                 <SelectTrigger className="w-full md:w-[300px] h-10">
                   <SelectValue placeholder={t('clanSelector.placeholder')} />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className="max-h-80">
                   {clanLogs.map((clan) => (
                     <SelectItem key={clan.tag} value={clan.tag}>
                       {clan.name} ({clan.tag})

--- a/app/[locale]/dashboard/[guildId]/reminders/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/reminders/page.tsx
@@ -818,7 +818,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                       <SelectTrigger className="w-full md:w-[250px]">
                         <SelectValue placeholder={t('clanSelector.placeholder')} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="max-h-80">
                         <SelectItem value="all">{t('clanSelector.allClans')}</SelectItem>
                         {clans.map((clan) => (
                           <SelectItem key={clan.tag} value={clan.tag}>
@@ -1173,7 +1173,7 @@ export default function RemindersPage() { // NOSONAR — React page component: c
                       <SelectTrigger id="dialog-clan">
                         <SelectValue placeholder={t('card.clanPlaceholder')} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="max-h-80">
                         {clans.map((clan) => (
                             <SelectItem key={clan.tag} value={clan.tag}>
                               {clan.name} ({clan.tag})

--- a/app/[locale]/dashboard/[guildId]/wars/page.tsx
+++ b/app/[locale]/dashboard/[guildId]/wars/page.tsx
@@ -731,7 +731,7 @@ export default function WarsPage() { // NOSONAR — React page component: comple
                       <SelectTrigger id="clan-filter">
                         <SelectValue placeholder={t('filters.clan')} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="max-h-80">
                         <SelectItem value="all">{t('filters.allClans')}</SelectItem>
                         {clans.map((clan) => (
                           <SelectItem key={clan.tag} value={clan.tag}>


### PR DESCRIPTION
## Summary
- cap clan dropdown menus in Logs, Reminders, and Wars
- keep long clan lists usable with internal scrolling

## Scope
This is a UI-only change. It does not change API handling, payload normalization, or war data fetching.

## Notes
Opened from Codex after local testing by Doctor MarZuk.

## Checks
- `fnm exec --using=26.5.0 npm.cmd run lint`
- `fnm exec --using=26.5.0 npm.cmd run build`
