### PR TITLE
Add landing settings submenus

### DIFF
--- a/app/explorations/clan-signal.css
+++ b/app/explorations/clan-signal.css
@@ -60,12 +60,13 @@
 .cs-nav-links a { color: #000; font-size: 0.82rem; font-weight: 730; transition: color 140ms ease-out; }
 .cs-nav-links a:hover { color: #000; }
 .cs-nav-actions { justify-self: end; display: flex; align-items: center; gap: 10px; }
-.cs-language-trigger {
+.cs-settings-trigger {
   min-height: 42px;
-  padding: 0 11px;
+  padding: 0 12px;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  justify-content: center;
+  gap: 8px;
   border: 1px solid rgb(0 0 0 / 0.24);
   border-radius: 12px;
   background: rgb(255 255 255 / 0.16);
@@ -75,19 +76,15 @@
   font-weight: 820;
   cursor: pointer;
 }
-.cs-language-trigger:focus-visible { outline: 3px solid #b78c20; outline-offset: 3px; }
-.cs-language-trigger:disabled { cursor: wait; opacity: 0.6; }
+.cs-settings-trigger svg, .cs-settings-option > svg { width: 16px; height: 16px; flex: 0 0 auto; }
+.cs-settings-trigger:focus-visible { outline: 3px solid #b78c20; outline-offset: 3px; }
+.cs-settings-trigger:disabled { cursor: wait; opacity: 0.6; }
 .cs-language-flag { position: relative; width: 20px; height: 14px; display: inline-block; flex: 0 0 20px; overflow: hidden; border-radius: 3px; box-shadow: 0 0 0 1px rgb(0 0 0 / 0.16); }
 .cs-language-flag img { position: static !important; width: 100% !important; height: 100% !important; object-fit: cover; }
-.cs-language-chevron { width: 6px; height: 6px; margin: -3px 1px 0 2px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(45deg); }
-.cs-language-menu { min-width: 178px !important; padding: 6px !important; border: 1px solid rgb(23 53 42 / 0.18) !important; border-radius: 14px !important; background: #eff9fd !important; color: #000 !important; box-shadow: 0 16px 42px rgb(23 53 42 / 0.18) !important; }
-.cs-language-option { min-height: 40px; gap: 10px !important; border-radius: 9px !important; color: #000 !important; font-size: 0.78rem !important; font-weight: 720 !important; cursor: pointer; }
-.cs-language-option:focus, .cs-language-option[data-highlighted] { background: #d5edf7 !important; }
-.cs-language-option[aria-current="true"] { background: #c1f1ff !important; }
-.cs-language-option[data-active="true"] { background: #c1f1ff !important; }
-.cs-language-code { margin-left: auto; color: rgb(0 0 0 / 0.5); font-size: 0.66rem; font-weight: 820; }
-.cs-language-separator { background: rgb(23 53 42 / 0.13) !important; }
-.cs-language-label { padding: 8px 8px 4px !important; color: rgb(0 0 0 / 0.5) !important; font-size: 0.62rem !important; font-weight: 820 !important; text-transform: uppercase; }
+.cs-settings-menu { min-width: 178px !important; padding: 6px !important; border: 1px solid rgb(23 53 42 / 0.18) !important; border-radius: 14px !important; background: #eff9fd !important; color: #000 !important; box-shadow: 0 16px 42px rgb(23 53 42 / 0.18) !important; }
+.cs-settings-option { min-height: 40px; gap: 10px !important; border-radius: 9px !important; color: #000 !important; font-size: 0.78rem !important; font-weight: 720 !important; cursor: pointer; }
+.cs-settings-option:focus, .cs-settings-option[data-highlighted], .cs-settings-option[data-state="open"] { background: #d5edf7 !important; }
+.cs-settings-check { margin-left: auto; }
 .cs-theme-swatch { width: 20px; height: 14px; flex: 0 0 auto; border-radius: 4px; box-shadow: 0 0 0 1px rgb(0 0 0 / 0.14); }
 .cs-theme-swatch-day { background: linear-gradient(135deg, #48a2d5 0 48%, #c1f1ff 48%); }
 .cs-theme-swatch-sunset { background: linear-gradient(135deg, #191b3a 0 44%, #a75d78 44% 70%, #e59a68 70%); }
@@ -355,17 +352,13 @@
 .clan-signal[data-cs-theme="sunset"] .cs-wordmark-sunset { opacity: 1; }
 .clan-signal[data-cs-theme="sunset"] .cs-nav-links a,
 .clan-signal[data-cs-theme="sunset"] .cs-nav-links a:hover,
-.clan-signal[data-cs-theme="sunset"] .cs-language-trigger { color: #fff2d5; }
-.clan-signal[data-cs-theme="sunset"] .cs-language-trigger { border-color: rgb(255 242 213 / 0.3); background: rgb(29 24 49 / 0.22); }
-.cs-language-menu[data-landing-theme="sunset"] { border-color: rgb(255 242 213 / 0.16) !important; background: #332b48 !important; color: #fff2d5 !important; }
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-option { color: #fff2d5 !important; }
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-option:focus,
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-option[data-highlighted] { background: #4c3c5a !important; }
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-option[aria-current="true"],
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-option[data-active="true"] { background: #65475d !important; }
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-code,
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-label { color: rgb(255 242 213 / 0.56) !important; }
-.cs-language-menu[data-landing-theme="sunset"] .cs-language-separator { background: rgb(255 242 213 / 0.14) !important; }
+.clan-signal[data-cs-theme="sunset"] .cs-settings-trigger { color: #fff2d5; }
+.clan-signal[data-cs-theme="sunset"] .cs-settings-trigger { border-color: rgb(255 242 213 / 0.3); background: rgb(29 24 49 / 0.22); }
+.cs-settings-menu[data-landing-theme="sunset"] { border-color: rgb(255 242 213 / 0.16) !important; background: #332b48 !important; color: #fff2d5 !important; }
+.cs-settings-menu[data-landing-theme="sunset"] .cs-settings-option { color: #fff2d5 !important; }
+.cs-settings-menu[data-landing-theme="sunset"] .cs-settings-option:focus,
+.cs-settings-menu[data-landing-theme="sunset"] .cs-settings-option[data-highlighted],
+.cs-settings-menu[data-landing-theme="sunset"] .cs-settings-option[data-state="open"] { background: #4c3c5a !important; }
 .clan-signal[data-cs-theme="sunset"] .cs-hero::before {
   background: linear-gradient(180deg, #181a3b 0, #744867 28%, #b96576 48%, #6a415d 68%, #2e2844 100%);
 }
@@ -423,7 +416,7 @@
   .cs-nav-brand { width: 126px; }
   .cs-nav .cs-button { min-height: 38px; padding-inline: 12px; font-size: 0.68rem; }
   .cs-nav .cs-button .cs-arrow { display: none; }
-  .cs-language-trigger { min-height: 38px; border-radius: 11px; }
+  .cs-settings-trigger { min-height: 38px; border-radius: 11px; }
   .cs-hero {
     --cs-cloud-strip-width: calc(300svh + 660px);
     --cs-sky-fade-height: 300px;

--- a/app/explorations/clan-signal.css
+++ b/app/explorations/clan-signal.css
@@ -84,6 +84,7 @@
 .cs-settings-menu { min-width: 178px !important; padding: 6px !important; border: 1px solid rgb(23 53 42 / 0.18) !important; border-radius: 14px !important; background: #eff9fd !important; color: #000 !important; box-shadow: 0 16px 42px rgb(23 53 42 / 0.18) !important; }
 .cs-settings-option { min-height: 40px; gap: 10px !important; border-radius: 9px !important; color: #000 !important; font-size: 0.78rem !important; font-weight: 720 !important; cursor: pointer; }
 .cs-settings-option:focus, .cs-settings-option[data-highlighted], .cs-settings-option[data-state="open"] { background: #d5edf7 !important; }
+.cs-settings-option > .absolute { display: none; }
 .cs-settings-check { margin-left: auto; }
 .cs-theme-swatch { width: 20px; height: 14px; flex: 0 0 auto; border-radius: 4px; box-shadow: 0 0 0 1px rgb(0 0 0 / 0.14); }
 .cs-theme-swatch-day { background: linear-gradient(135deg, #48a2d5 0 48%, #c1f1ff 48%); }
@@ -381,6 +382,47 @@
 .clan-signal[data-cs-theme="sunset"] .cs-footer-links a:hover,
 .clan-signal[data-cs-theme="sunset"] .cs-footer-link-disabled { color: #fff2d5; }
 .clan-signal[data-cs-theme="sunset"] .cs-legal { border-color: rgb(255 242 213 / 0.22); color: #fff2d5 !important; text-shadow: 0 1px rgb(0 0 0 / 0.28); }
+
+@media (prefers-color-scheme: dark) {
+  .clan-signal[data-cs-theme="system"] {
+    --cs-bg: #2e2844;
+    --cs-surface: #463954;
+    --cs-surface-green: #3a3549;
+    --cs-surface-blue: #433650;
+    --cs-surface-gold: #60424b;
+    --cs-ink: #fff2d5;
+    --cs-muted: #dbcbd3;
+    --cs-line: rgb(255 242 213 / 0.18);
+    --cs-gold: #e3ad55;
+    --cs-gold-hover: #efbb66;
+  }
+  .clan-signal[data-cs-theme="system"] .cs-wordmark-day { opacity: 0; }
+  .clan-signal[data-cs-theme="system"] .cs-wordmark-sunset { opacity: 1; }
+  .clan-signal[data-cs-theme="system"] .cs-nav-links a,
+  .clan-signal[data-cs-theme="system"] .cs-nav-links a:hover,
+  .clan-signal[data-cs-theme="system"] .cs-settings-trigger { color: #fff2d5; }
+  .clan-signal[data-cs-theme="system"] .cs-settings-trigger { border-color: rgb(255 242 213 / 0.3); background: rgb(29 24 49 / 0.22); }
+  .clan-signal[data-cs-theme="system"] .cs-hero::before { background: linear-gradient(180deg, #181a3b 0, #744867 28%, #b96576 48%, #6a415d 68%, #2e2844 100%); }
+  .clan-signal[data-cs-theme="system"] .cs-hero::after,
+  .clan-signal[data-cs-theme="system"] .cs-mobile-cloud-track { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.82; }
+  .clan-signal[data-cs-theme="system"] .cs-mobile::before { background: linear-gradient(180deg, #2e2844 0, rgb(46 40 68 / 0.74) 42%, transparent 100%); }
+  .clan-signal[data-cs-theme="system"] .cs-button { color: #281d2f !important; border-color: rgb(255 225 159 / 0.3); box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.36), 0 10px 28px rgb(16 11 31 / 0.2); }
+  .clan-signal[data-cs-theme="system"] .cs-text-link { border-color: rgb(255 242 213 / 0.34); }
+  .clan-signal[data-cs-theme="system"] .cs-disabled:hover { border-color: rgb(255 242 213 / 0.34); }
+  .clan-signal[data-cs-theme="system"] .cs-feature-icon { background: #4b4058; box-shadow: 0 8px 24px rgb(15 10 29 / 0.2); }
+  .clan-signal[data-cs-theme="system"] .cs-bot-art { background: #29292d; }
+  .clan-signal[data-cs-theme="system"] .cs-footer-scene::after { background: linear-gradient(180deg, transparent, rgb(64 63 66 / 0.5) 34%, rgb(52 66 48 / 0.86) 100%); }
+  .clan-signal[data-cs-theme="system"] .cs-bottom-landscape-image { filter: brightness(0.52) saturate(1.12) hue-rotate(-7deg); }
+  .clan-signal[data-cs-theme="system"] .cs-legal-hero { background: linear-gradient(180deg, #181a3b 0%, #744867 42%, #b96576 72%, var(--cs-bg) 100%); }
+  .clan-signal[data-cs-theme="system"] .cs-legal-hero::after { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.68; }
+  .clan-signal[data-cs-theme="system"] .cs-legal-eyebrow { color: #fff2d5 !important; }
+  .clan-signal[data-cs-theme="system"] .cs-legal-notice { background: rgb(24 26 59 / 0.2); }
+  .clan-signal[data-cs-theme="system"] .cs-footer-brand p,
+  .clan-signal[data-cs-theme="system"] .cs-footer-links a,
+  .clan-signal[data-cs-theme="system"] .cs-footer-links a:hover,
+  .clan-signal[data-cs-theme="system"] .cs-footer-link-disabled { color: #fff2d5; }
+  .clan-signal[data-cs-theme="system"] .cs-legal { border-color: rgb(255 242 213 / 0.22); color: #fff2d5 !important; text-shadow: 0 1px rgb(0 0 0 / 0.28); }
+}
 
 @media (prefers-reduced-motion: no-preference) {
   .cs-enter { animation: cs-enter 380ms cubic-bezier(.22, .61, .36, 1) both; }

--- a/app/explorations/clan-signal.css
+++ b/app/explorations/clan-signal.css
@@ -82,7 +82,7 @@
 .cs-language-flag { position: relative; width: 20px; height: 14px; display: inline-block; flex: 0 0 20px; overflow: hidden; border-radius: 3px; box-shadow: 0 0 0 1px rgb(0 0 0 / 0.16); }
 .cs-language-flag img { position: static !important; width: 100% !important; height: 100% !important; object-fit: cover; }
 .cs-settings-menu { min-width: 178px !important; padding: 6px !important; border: 1px solid rgb(23 53 42 / 0.18) !important; border-radius: 14px !important; background: #eff9fd !important; color: #000 !important; box-shadow: 0 16px 42px rgb(23 53 42 / 0.18) !important; }
-.cs-settings-option { min-height: 40px; gap: 10px !important; border-radius: 9px !important; color: #000 !important; font-size: 0.78rem !important; font-weight: 720 !important; cursor: pointer; }
+.cs-settings-option { min-height: 40px; gap: 10px !important; padding-left: 8px !important; padding-right: 8px !important; border-radius: 9px !important; color: #000 !important; font-size: 0.78rem !important; font-weight: 720 !important; cursor: pointer; }
 .cs-settings-option:focus, .cs-settings-option[data-highlighted], .cs-settings-option[data-state="open"] { background: #d5edf7 !important; }
 .cs-settings-option > .absolute { display: none; }
 .cs-settings-check { margin-left: auto; }

--- a/app/explorations/clan-signal.css
+++ b/app/explorations/clan-signal.css
@@ -383,8 +383,7 @@
 .clan-signal[data-cs-theme="sunset"] .cs-footer-link-disabled { color: #fff2d5; }
 .clan-signal[data-cs-theme="sunset"] .cs-legal { border-color: rgb(255 242 213 / 0.22); color: #fff2d5 !important; text-shadow: 0 1px rgb(0 0 0 / 0.28); }
 
-@media (prefers-color-scheme: dark) {
-  .clan-signal[data-cs-theme="system"] {
+.dark .clan-signal[data-cs-theme="system"] {
     --cs-bg: #2e2844;
     --cs-surface: #463954;
     --cs-surface-green: #3a3549;
@@ -392,37 +391,36 @@
     --cs-surface-gold: #60424b;
     --cs-ink: #fff2d5;
     --cs-muted: #dbcbd3;
-    --cs-line: rgb(255 242 213 / 0.18);
-    --cs-gold: #e3ad55;
-    --cs-gold-hover: #efbb66;
-  }
-  .clan-signal[data-cs-theme="system"] .cs-wordmark-day { opacity: 0; }
-  .clan-signal[data-cs-theme="system"] .cs-wordmark-sunset { opacity: 1; }
-  .clan-signal[data-cs-theme="system"] .cs-nav-links a,
-  .clan-signal[data-cs-theme="system"] .cs-nav-links a:hover,
-  .clan-signal[data-cs-theme="system"] .cs-settings-trigger { color: #fff2d5; }
-  .clan-signal[data-cs-theme="system"] .cs-settings-trigger { border-color: rgb(255 242 213 / 0.3); background: rgb(29 24 49 / 0.22); }
-  .clan-signal[data-cs-theme="system"] .cs-hero::before { background: linear-gradient(180deg, #181a3b 0, #744867 28%, #b96576 48%, #6a415d 68%, #2e2844 100%); }
-  .clan-signal[data-cs-theme="system"] .cs-hero::after,
-  .clan-signal[data-cs-theme="system"] .cs-mobile-cloud-track { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.82; }
-  .clan-signal[data-cs-theme="system"] .cs-mobile::before { background: linear-gradient(180deg, #2e2844 0, rgb(46 40 68 / 0.74) 42%, transparent 100%); }
-  .clan-signal[data-cs-theme="system"] .cs-button { color: #281d2f !important; border-color: rgb(255 225 159 / 0.3); box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.36), 0 10px 28px rgb(16 11 31 / 0.2); }
-  .clan-signal[data-cs-theme="system"] .cs-text-link { border-color: rgb(255 242 213 / 0.34); }
-  .clan-signal[data-cs-theme="system"] .cs-disabled:hover { border-color: rgb(255 242 213 / 0.34); }
-  .clan-signal[data-cs-theme="system"] .cs-feature-icon { background: #4b4058; box-shadow: 0 8px 24px rgb(15 10 29 / 0.2); }
-  .clan-signal[data-cs-theme="system"] .cs-bot-art { background: #29292d; }
-  .clan-signal[data-cs-theme="system"] .cs-footer-scene::after { background: linear-gradient(180deg, transparent, rgb(64 63 66 / 0.5) 34%, rgb(52 66 48 / 0.86) 100%); }
-  .clan-signal[data-cs-theme="system"] .cs-bottom-landscape-image { filter: brightness(0.52) saturate(1.12) hue-rotate(-7deg); }
-  .clan-signal[data-cs-theme="system"] .cs-legal-hero { background: linear-gradient(180deg, #181a3b 0%, #744867 42%, #b96576 72%, var(--cs-bg) 100%); }
-  .clan-signal[data-cs-theme="system"] .cs-legal-hero::after { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.68; }
-  .clan-signal[data-cs-theme="system"] .cs-legal-eyebrow { color: #fff2d5 !important; }
-  .clan-signal[data-cs-theme="system"] .cs-legal-notice { background: rgb(24 26 59 / 0.2); }
-  .clan-signal[data-cs-theme="system"] .cs-footer-brand p,
-  .clan-signal[data-cs-theme="system"] .cs-footer-links a,
-  .clan-signal[data-cs-theme="system"] .cs-footer-links a:hover,
-  .clan-signal[data-cs-theme="system"] .cs-footer-link-disabled { color: #fff2d5; }
-  .clan-signal[data-cs-theme="system"] .cs-legal { border-color: rgb(255 242 213 / 0.22); color: #fff2d5 !important; text-shadow: 0 1px rgb(0 0 0 / 0.28); }
+  --cs-line: rgb(255 242 213 / 0.18);
+  --cs-gold: #e3ad55;
+  --cs-gold-hover: #efbb66;
 }
+.dark .clan-signal[data-cs-theme="system"] .cs-wordmark-day { opacity: 0; }
+.dark .clan-signal[data-cs-theme="system"] .cs-wordmark-sunset { opacity: 1; }
+.dark .clan-signal[data-cs-theme="system"] .cs-nav-links a,
+.dark .clan-signal[data-cs-theme="system"] .cs-nav-links a:hover,
+.dark .clan-signal[data-cs-theme="system"] .cs-settings-trigger { color: #fff2d5; }
+.dark .clan-signal[data-cs-theme="system"] .cs-settings-trigger { border-color: rgb(255 242 213 / 0.3); background: rgb(29 24 49 / 0.22); }
+.dark .clan-signal[data-cs-theme="system"] .cs-hero::before { background: linear-gradient(180deg, #181a3b 0, #744867 28%, #b96576 48%, #6a415d 68%, #2e2844 100%); }
+.dark .clan-signal[data-cs-theme="system"] .cs-hero::after,
+.dark .clan-signal[data-cs-theme="system"] .cs-mobile-cloud-track { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.82; }
+.dark .clan-signal[data-cs-theme="system"] .cs-mobile::before { background: linear-gradient(180deg, #2e2844 0, rgb(46 40 68 / 0.74) 42%, transparent 100%); }
+.dark .clan-signal[data-cs-theme="system"] .cs-button { color: #281d2f !important; border-color: rgb(255 225 159 / 0.3); box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.36), 0 10px 28px rgb(16 11 31 / 0.2); }
+.dark .clan-signal[data-cs-theme="system"] .cs-text-link { border-color: rgb(255 242 213 / 0.34); }
+.dark .clan-signal[data-cs-theme="system"] .cs-disabled:hover { border-color: rgb(255 242 213 / 0.34); }
+.dark .clan-signal[data-cs-theme="system"] .cs-feature-icon { background: #4b4058; box-shadow: 0 8px 24px rgb(15 10 29 / 0.2); }
+.dark .clan-signal[data-cs-theme="system"] .cs-bot-art { background: #29292d; }
+.dark .clan-signal[data-cs-theme="system"] .cs-footer-scene::after { background: linear-gradient(180deg, transparent, rgb(64 63 66 / 0.5) 34%, rgb(52 66 48 / 0.86) 100%); }
+.dark .clan-signal[data-cs-theme="system"] .cs-bottom-landscape-image { filter: brightness(0.52) saturate(1.12) hue-rotate(-7deg); }
+.dark .clan-signal[data-cs-theme="system"] .cs-legal-hero { background: linear-gradient(180deg, #181a3b 0%, #744867 42%, #b96576 72%, var(--cs-bg) 100%); }
+.dark .clan-signal[data-cs-theme="system"] .cs-legal-hero::after { filter: grayscale(1) sepia(0.55) saturate(1.25) hue-rotate(330deg) brightness(0.76) contrast(1.05); opacity: 0.68; }
+.dark .clan-signal[data-cs-theme="system"] .cs-legal-eyebrow { color: #fff2d5 !important; }
+.dark .clan-signal[data-cs-theme="system"] .cs-legal-notice { background: rgb(24 26 59 / 0.2); }
+.dark .clan-signal[data-cs-theme="system"] .cs-footer-brand p,
+.dark .clan-signal[data-cs-theme="system"] .cs-footer-links a,
+.dark .clan-signal[data-cs-theme="system"] .cs-footer-links a:hover,
+.dark .clan-signal[data-cs-theme="system"] .cs-footer-link-disabled { color: #fff2d5; }
+.dark .clan-signal[data-cs-theme="system"] .cs-legal { border-color: rgb(255 242 213 / 0.22); color: #fff2d5 !important; text-shadow: 0 1px rgb(0 0 0 / 0.28); }
 
 @media (prefers-reduced-motion: no-preference) {
   .cs-enter { animation: cs-enter 380ms cubic-bezier(.22, .61, .36, 1) both; }

--- a/components/landing/explorations/clan-signal.tsx
+++ b/components/landing/explorations/clan-signal.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 import { ClanSignalHeroModel } from "./clan-signal/hero-model";
 import { ClanSignalWordmark } from "./clan-signal/brand";
@@ -11,7 +10,6 @@ import "../../../app/explorations/clan-signal.css";
 
 const SHARED = "/concepts/local/assets";
 const ICONS = `${SHARED}/bot/icons`;
-const LANDING_THEME_COOKIE = "CK_LANDING_THEME";
 
 type Feature = {
   icon: string;
@@ -61,11 +59,6 @@ function FeatureList({ features }: { features: readonly Feature[] }) {
 
 export async function ClanSignal() {
   const t = await getTranslations("ClanSignal");
-  const cookieStore = await cookies();
-  const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
-  const landingTheme = storedLandingTheme === "day" || storedLandingTheme === "sunset"
-    ? storedLandingTheme
-    : "system";
   const headlinePhrases = [
     [t("hero.phrases.run.first"), t("hero.phrases.run.second"), t("hero.phrases.run.third")],
     [t("hero.phrases.accounts.first"), t("hero.phrases.accounts.second"), t("hero.phrases.accounts.third")],
@@ -88,7 +81,7 @@ export async function ClanSignal() {
   ] as const;
 
   return (
-    <main className="clan-signal" data-cs-theme={landingTheme}>
+    <main className="clan-signal" data-cs-theme="system">
       <header className="cs-nav-shell">
         <nav className="cs-nav" aria-label={t("navigation.ariaLabel")}>
           <Link href="/" aria-label={t("navigation.homeLabel")} className="cs-nav-brand">
@@ -108,7 +101,6 @@ export async function ClanSignal() {
               systemAppearanceLabel={t("appearance.system")}
               dayLabel={t("appearance.day")}
               sunsetLabel={t("appearance.sunset")}
-              initialTheme={landingTheme}
             />
             <a className="cs-button cs-button-small" href="https://invite.clashk.ing/" target="_blank" rel="noreferrer">
               {t("actions.addToDiscord")} <ArrowAsset />

--- a/components/landing/explorations/clan-signal.tsx
+++ b/components/landing/explorations/clan-signal.tsx
@@ -62,7 +62,10 @@ function FeatureList({ features }: { features: readonly Feature[] }) {
 export async function ClanSignal() {
   const t = await getTranslations("ClanSignal");
   const cookieStore = await cookies();
-  const landingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value === "sunset" ? "sunset" : "day";
+  const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
+  const landingTheme = storedLandingTheme === "sunset" || storedLandingTheme === "system"
+    ? storedLandingTheme
+    : "day";
   const headlinePhrases = [
     [t("hero.phrases.run.first"), t("hero.phrases.run.second"), t("hero.phrases.run.third")],
     [t("hero.phrases.accounts.first"), t("hero.phrases.accounts.second"), t("hero.phrases.accounts.third")],

--- a/components/landing/explorations/clan-signal.tsx
+++ b/components/landing/explorations/clan-signal.tsx
@@ -99,7 +99,10 @@ export async function ClanSignal() {
           <div className="cs-nav-actions">
             <LandingLanguageSwitcher
               label={t("language.label")}
+              languageLabel={t("language.label")}
               appearanceLabel={t("appearance.label")}
+              systemLanguageLabel={t("language.system")}
+              systemAppearanceLabel={t("appearance.system")}
               dayLabel={t("appearance.day")}
               sunsetLabel={t("appearance.sunset")}
               initialTheme={landingTheme}

--- a/components/landing/explorations/clan-signal.tsx
+++ b/components/landing/explorations/clan-signal.tsx
@@ -98,7 +98,7 @@ export async function ClanSignal() {
           </div>
           <div className="cs-nav-actions">
             <LandingLanguageSwitcher
-              label={t("language.label")}
+              label={t("settings.label")}
               languageLabel={t("language.label")}
               appearanceLabel={t("appearance.label")}
               systemLanguageLabel={t("language.system")}

--- a/components/landing/explorations/clan-signal.tsx
+++ b/components/landing/explorations/clan-signal.tsx
@@ -63,9 +63,9 @@ export async function ClanSignal() {
   const t = await getTranslations("ClanSignal");
   const cookieStore = await cookies();
   const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
-  const landingTheme = storedLandingTheme === "sunset" || storedLandingTheme === "system"
+  const landingTheme = storedLandingTheme === "day" || storedLandingTheme === "sunset"
     ? storedLandingTheme
-    : "day";
+    : "system";
   const headlinePhrases = [
     [t("hero.phrases.run.first"), t("hero.phrases.run.second"), t("hero.phrases.run.third")],
     [t("hero.phrases.accounts.first"), t("hero.phrases.accounts.second"), t("hero.phrases.accounts.third")],

--- a/components/landing/explorations/clan-signal/language-switcher.tsx
+++ b/components/landing/explorations/clan-signal/language-switcher.tsx
@@ -8,7 +8,8 @@ import { Check, Computer, Globe, Moon, Settings, Sun } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -31,7 +32,7 @@ type LandingLanguageSwitcherProps = {
   systemAppearanceLabel: string;
   dayLabel: string;
   sunsetLabel: string;
-  initialTheme: LandingTheme;
+  initialTheme: LandingThemeMode;
 };
 
 type LandingTheme = "day" | "sunset";
@@ -55,7 +56,7 @@ export function LandingLanguageSwitcher({
 }: Readonly<LandingLanguageSwitcherProps>) {
   const locale = useLocale() as SupportedLocale;
   const router = useRouter();
-  const [landingTheme, setLandingTheme] = useState<LandingTheme>(initialTheme);
+  const [landingTheme, setLandingTheme] = useState<LandingTheme>(initialTheme === "sunset" ? "sunset" : "day");
   const [themeMode, setThemeMode] = useState<LandingThemeMode>(initialTheme);
   const [localeMode, setLocaleMode] = useState<LocaleMode>("manual");
   const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
@@ -80,10 +81,6 @@ export function LandingLanguageSwitcher({
       }
     }
 
-    const storedTheme = document.cookie.match(new RegExp(`(?:^|; )${LANDING_THEME_COOKIE}=([^;]*)`))?.[1];
-    if (storedTheme === "system") {
-      setThemeMode("system");
-    }
   }, [locale, router]);
 
   useEffect(() => {
@@ -106,6 +103,28 @@ export function LandingLanguageSwitcher({
     startTransition(() => router.refresh());
   };
 
+  const applyThemePreference = (value: string) => {
+    if (value === "system") {
+      applyTheme(resolveSystemTheme(), "system");
+      return;
+    }
+
+    if (value === "day" || value === "sunset") {
+      applyTheme(value, value);
+    }
+  };
+
+  const applyLocalePreference = (value: string) => {
+    if (value === "system") {
+      switchLocale(resolveBrowserLocale(navigator.languages), "browser");
+      return;
+    }
+
+    if (LANGUAGE_OPTIONS.some((language) => language.code === value)) {
+      switchLocale(value as SupportedLocale, "manual");
+    }
+  };
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -120,21 +139,23 @@ export function LandingLanguageSwitcher({
             <span>{appearanceLabel}</span>
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="cs-settings-menu" data-landing-theme={landingTheme} sideOffset={8} alignOffset={-6}>
-            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme(resolveSystemTheme(), "system")}>
+            <DropdownMenuRadioGroup value={themeMode} onValueChange={applyThemePreference}>
+            <DropdownMenuRadioItem value="system" className="cs-settings-option">
               <Computer aria-hidden="true" />
               <span>{systemAppearanceLabel}</span>
               {themeMode === "system" && <Check className="cs-settings-check" aria-hidden="true" />}
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme("day", "day")}>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="day" className="cs-settings-option">
               <span className="cs-theme-swatch cs-theme-swatch-day" aria-hidden="true" />
               <span>{dayLabel}</span>
               {themeMode === "day" && <Check className="cs-settings-check" aria-hidden="true" />}
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme("sunset", "sunset")}>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="sunset" className="cs-settings-option">
               <span className="cs-theme-swatch cs-theme-swatch-sunset" aria-hidden="true" />
               <span>{sunsetLabel}</span>
               {themeMode === "sunset" && <Check className="cs-settings-check" aria-hidden="true" />}
-            </DropdownMenuItem>
+            </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
 
@@ -144,18 +165,20 @@ export function LandingLanguageSwitcher({
             <span>{languageLabel}</span>
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="cs-settings-menu" data-landing-theme={landingTheme} sideOffset={8} alignOffset={-6}>
-            <DropdownMenuItem className="cs-settings-option" onClick={() => switchLocale(resolveBrowserLocale(navigator.languages), "browser")}>
+            <DropdownMenuRadioGroup value={localeMode === "browser" ? "system" : locale} onValueChange={applyLocalePreference}>
+            <DropdownMenuRadioItem value="system" className="cs-settings-option">
               <Globe aria-hidden="true" />
               <span>{systemLanguageLabel}</span>
               {localeMode === "browser" && <Check className="cs-settings-check" aria-hidden="true" />}
-            </DropdownMenuItem>
+            </DropdownMenuRadioItem>
             {LANGUAGE_OPTIONS.map((language) => (
-              <DropdownMenuItem key={language.code} className="cs-settings-option" onClick={() => switchLocale(language.code, "manual")}>
+              <DropdownMenuRadioItem key={language.code} value={language.code} className="cs-settings-option">
                 <span className="cs-language-flag"><Image src={`https://flagcdn.com/w40/${language.flagCode}.png`} alt="" width={20} height={14} /></span>
                 <span>{language.name}</span>
                 {localeMode === "manual" && locale === language.code && <Check className="cs-settings-check" aria-hidden="true" />}
-              </DropdownMenuItem>
+              </DropdownMenuRadioItem>
             ))}
+            </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
       </DropdownMenuContent>

--- a/components/landing/explorations/clan-signal/language-switcher.tsx
+++ b/components/landing/explorations/clan-signal/language-switcher.tsx
@@ -3,120 +3,152 @@
 import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useRef, useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
+import { Check, Computer, Globe, Moon, Settings, Sun } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  getLocaleModeFromCookie,
   LANGUAGE_OPTIONS,
   LOCALE_MODE_COOKIE,
+  resolveBrowserLocale,
+  type LocaleMode,
   type SupportedLocale,
 } from "@/lib/locale-preference";
 
 type LandingLanguageSwitcherProps = {
   label: string;
+  languageLabel: string;
   appearanceLabel: string;
+  systemLanguageLabel: string;
+  systemAppearanceLabel: string;
   dayLabel: string;
   sunsetLabel: string;
   initialTheme: LandingTheme;
 };
 
 type LandingTheme = "day" | "sunset";
+type LandingThemeMode = LandingTheme | "system";
 
 const LANDING_THEME_COOKIE = "CK_LANDING_THEME";
 
+function resolveSystemTheme(): LandingTheme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "sunset" : "day";
+}
+
 export function LandingLanguageSwitcher({
   label,
+  languageLabel,
   appearanceLabel,
+  systemLanguageLabel,
+  systemAppearanceLabel,
   dayLabel,
   sunsetLabel,
   initialTheme,
 }: Readonly<LandingLanguageSwitcherProps>) {
   const locale = useLocale() as SupportedLocale;
   const router = useRouter();
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const [landingTheme, setLandingTheme] = useState<LandingTheme>(initialTheme);
+  const [themeMode, setThemeMode] = useState<LandingThemeMode>(initialTheme);
+  const [localeMode, setLocaleMode] = useState<LocaleMode>("manual");
+  const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const currentLanguage = LANGUAGE_OPTIONS.find((language) => language.code === locale) ?? LANGUAGE_OPTIONS[0];
 
-  const switchLocale = (nextLocale: SupportedLocale) => {
-    // eslint-disable-next-line react-hooks/immutability -- locale preference is persisted by next-intl's cookie contract
-    document.cookie = `${LOCALE_MODE_COOKIE}=manual; path=/; max-age=31536000; SameSite=Lax`;
-    // eslint-disable-next-line react-hooks/immutability -- locale preference is persisted by next-intl's cookie contract
-    document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; SameSite=Lax`;
-    startTransition(() => router.refresh());
+  const applyTheme = (nextTheme: LandingTheme, mode: LandingThemeMode) => {
+    setLandingTheme(nextTheme);
+    setThemeMode(mode);
+    document.cookie = `${LANDING_THEME_COOKIE}=${mode}; path=/; max-age=31536000; SameSite=Lax`;
+    document.querySelector<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
   };
 
-  const switchLandingTheme = (nextTheme: LandingTheme) => {
-    setLandingTheme(nextTheme);
-    document.cookie = `${LANDING_THEME_COOKIE}=${nextTheme}; path=/; max-age=31536000; SameSite=Lax`;
-    triggerRef.current?.closest<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
+  useEffect(() => {
+    const nextLocaleMode = getLocaleModeFromCookie(document.cookie);
+    setLocaleMode(nextLocaleMode);
+    if (nextLocaleMode === "browser") {
+      const browserLocale = resolveBrowserLocale(navigator.languages);
+      if (browserLocale !== locale) {
+        document.cookie = `NEXT_LOCALE=${browserLocale}; path=/; max-age=31536000; SameSite=Lax`;
+        router.refresh();
+      }
+    }
+
+    const storedTheme = document.cookie.match(new RegExp(`(?:^|; )${LANDING_THEME_COOKIE}=([^;]*)`))?.[1];
+    if (storedTheme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const syncSystemTheme = () => applyTheme(resolveSystemTheme(), "system");
+    syncSystemTheme();
+    mediaQuery.addEventListener("change", syncSystemTheme);
+    return () => mediaQuery.removeEventListener("change", syncSystemTheme);
+  }, [locale, router]);
+
+  const switchLocale = (nextLocale: SupportedLocale, mode: LocaleMode) => {
+    document.cookie = `${LOCALE_MODE_COOKIE}=${mode}; path=/; max-age=31536000; SameSite=Lax`;
+    document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; SameSite=Lax`;
+    setLocaleMode(mode);
+    startTransition(() => router.refresh());
   };
 
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <button ref={triggerRef} className="cs-language-trigger" type="button" aria-label={label} disabled={isPending}>
-          <span className="cs-language-flag">
-            <Image
-              src={`https://flagcdn.com/w40/${currentLanguage.flagCode}.png`}
-              alt=""
-              width={20}
-              height={14}
-            />
-          </span>
-          <span>{currentLanguage.code.toUpperCase()}</span>
-          <span className="cs-language-chevron" aria-hidden="true" />
+        <button className="cs-settings-trigger" type="button" aria-label={label} disabled={isPending}>
+          <Settings aria-hidden="true" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        sideOffset={6}
-        className="cs-language-menu"
-        data-landing-theme={landingTheme}
-      >
-        {LANGUAGE_OPTIONS.map((language) => (
-          <DropdownMenuItem
-            key={language.code}
-            className="cs-language-option"
-            aria-current={locale === language.code ? "true" : undefined}
-            onClick={() => switchLocale(language.code)}
-          >
-            <span className="cs-language-flag">
-              <Image
-                src={`https://flagcdn.com/w40/${language.flagCode}.png`}
-                alt=""
-                width={20}
-                height={14}
-              />
-            </span>
-            <span>{language.name}</span>
-            <span className="cs-language-code">{language.code.toUpperCase()}</span>
-          </DropdownMenuItem>
-        ))}
-        <DropdownMenuSeparator className="cs-language-separator" />
-        <DropdownMenuLabel className="cs-language-label">{appearanceLabel}</DropdownMenuLabel>
-        <DropdownMenuItem
-          className="cs-language-option"
-          data-active={landingTheme === "day" ? "true" : undefined}
-          onClick={() => switchLandingTheme("day")}
-        >
-          <span className="cs-theme-swatch cs-theme-swatch-day" aria-hidden="true" />
-          <span>{dayLabel}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="cs-language-option"
-          data-active={landingTheme === "sunset" ? "true" : undefined}
-          onClick={() => switchLandingTheme("sunset")}
-        >
-          <span className="cs-theme-swatch cs-theme-swatch-sunset" aria-hidden="true" />
-          <span>{sunsetLabel}</span>
-        </DropdownMenuItem>
+      <DropdownMenuContent align="end" sideOffset={8} className="cs-settings-menu" data-landing-theme={landingTheme}>
+        <DropdownMenuSub open={openSubmenu === "appearance"} onOpenChange={(open) => setOpenSubmenu(open ? "appearance" : null)}>
+          <DropdownMenuSubTrigger className="cs-settings-option">
+            {landingTheme === "sunset" ? <Moon aria-hidden="true" /> : <Sun aria-hidden="true" />}
+            <span>{appearanceLabel}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="cs-settings-menu" data-landing-theme={landingTheme} sideOffset={8} alignOffset={-6}>
+            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme(resolveSystemTheme(), "system")}>
+              <Computer aria-hidden="true" />
+              <span>{systemAppearanceLabel}</span>
+              {themeMode === "system" && <Check className="cs-settings-check" aria-hidden="true" />}
+            </DropdownMenuItem>
+            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme("day", "day")}>
+              <span className="cs-theme-swatch cs-theme-swatch-day" aria-hidden="true" />
+              <span>{dayLabel}</span>
+              {themeMode === "day" && <Check className="cs-settings-check" aria-hidden="true" />}
+            </DropdownMenuItem>
+            <DropdownMenuItem className="cs-settings-option" onClick={() => applyTheme("sunset", "sunset")}>
+              <span className="cs-theme-swatch cs-theme-swatch-sunset" aria-hidden="true" />
+              <span>{sunsetLabel}</span>
+              {themeMode === "sunset" && <Check className="cs-settings-check" aria-hidden="true" />}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub open={openSubmenu === "language"} onOpenChange={(open) => setOpenSubmenu(open ? "language" : null)}>
+          <DropdownMenuSubTrigger className="cs-settings-option">
+            <span className="cs-language-flag"><Image src={`https://flagcdn.com/w40/${currentLanguage.flagCode}.png`} alt="" width={20} height={14} /></span>
+            <span>{languageLabel}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="cs-settings-menu" data-landing-theme={landingTheme} sideOffset={8} alignOffset={-6}>
+            <DropdownMenuItem className="cs-settings-option" onClick={() => switchLocale(resolveBrowserLocale(navigator.languages), "browser")}>
+              <Globe aria-hidden="true" />
+              <span>{systemLanguageLabel}</span>
+              {localeMode === "browser" && <Check className="cs-settings-check" aria-hidden="true" />}
+            </DropdownMenuItem>
+            {LANGUAGE_OPTIONS.map((language) => (
+              <DropdownMenuItem key={language.code} className="cs-settings-option" onClick={() => switchLocale(language.code, "manual")}>
+                <span className="cs-language-flag"><Image src={`https://flagcdn.com/w40/${language.flagCode}.png`} alt="" width={20} height={14} /></span>
+                <span>{language.name}</span>
+                {localeMode === "manual" && locale === language.code && <Check className="cs-settings-check" aria-hidden="true" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/components/landing/explorations/clan-signal/language-switcher.tsx
+++ b/components/landing/explorations/clan-signal/language-switcher.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
+import { useTheme } from "next-themes";
 import { Check, Computer, Globe, Moon, Settings, Sun } from "lucide-react";
 import {
   DropdownMenu,
@@ -32,17 +33,9 @@ type LandingLanguageSwitcherProps = {
   systemAppearanceLabel: string;
   dayLabel: string;
   sunsetLabel: string;
-  initialTheme: LandingThemeMode;
 };
 
 type LandingTheme = "day" | "sunset";
-type LandingThemeMode = LandingTheme | "system";
-
-const LANDING_THEME_COOKIE = "CK_LANDING_THEME";
-
-function resolveSystemTheme(): LandingTheme {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "sunset" : "day";
-}
 
 export function LandingLanguageSwitcher({
   label,
@@ -52,23 +45,15 @@ export function LandingLanguageSwitcher({
   systemAppearanceLabel,
   dayLabel,
   sunsetLabel,
-  initialTheme,
 }: Readonly<LandingLanguageSwitcherProps>) {
   const locale = useLocale() as SupportedLocale;
   const router = useRouter();
-  const [landingTheme, setLandingTheme] = useState<LandingTheme>(initialTheme === "sunset" ? "sunset" : "day");
-  const [themeMode, setThemeMode] = useState<LandingThemeMode>(initialTheme);
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const [landingTheme, setLandingTheme] = useState<LandingTheme>("day");
   const [localeMode, setLocaleMode] = useState<LocaleMode>("manual");
   const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const currentLanguage = LANGUAGE_OPTIONS.find((language) => language.code === locale) ?? LANGUAGE_OPTIONS[0];
-
-  const applyTheme = (nextTheme: LandingTheme, mode: LandingThemeMode) => {
-    setLandingTheme(nextTheme);
-    setThemeMode(mode);
-    document.cookie = `${LANDING_THEME_COOKIE}=${mode}; path=/; max-age=31536000; SameSite=Lax`;
-    document.querySelector<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
-  };
 
   useEffect(() => {
     const nextLocaleMode = getLocaleModeFromCookie(document.cookie);
@@ -84,17 +69,10 @@ export function LandingLanguageSwitcher({
   }, [locale, router]);
 
   useEffect(() => {
-    if (themeMode !== "system") return;
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const syncSystemTheme = () => {
-      const nextTheme = resolveSystemTheme();
-      setLandingTheme(nextTheme);
-      document.querySelector<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
-    };
-    syncSystemTheme();
-    mediaQuery.addEventListener("change", syncSystemTheme);
-    return () => mediaQuery.removeEventListener("change", syncSystemTheme);
-  }, [themeMode]);
+    const nextTheme = resolvedTheme === "dark" ? "sunset" : "day";
+    setLandingTheme(nextTheme);
+    document.querySelector<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
+  }, [resolvedTheme]);
 
   const switchLocale = (nextLocale: SupportedLocale, mode: LocaleMode) => {
     document.cookie = `${LOCALE_MODE_COOKIE}=${mode}; path=/; max-age=31536000; SameSite=Lax`;
@@ -105,14 +83,15 @@ export function LandingLanguageSwitcher({
 
   const applyThemePreference = (value: string) => {
     if (value === "system") {
-      applyTheme(resolveSystemTheme(), "system");
+      setTheme("system");
       return;
     }
 
-    if (value === "day" || value === "sunset") {
-      applyTheme(value, value);
-    }
+    if (value === "day") setTheme("light");
+    if (value === "sunset") setTheme("dark");
   };
+
+  const themeMode = theme === "light" ? "day" : theme === "dark" ? "sunset" : "system";
 
   const applyLocalePreference = (value: string) => {
     if (value === "system") {

--- a/components/landing/explorations/clan-signal/language-switcher.tsx
+++ b/components/landing/explorations/clan-signal/language-switcher.tsx
@@ -81,14 +81,23 @@ export function LandingLanguageSwitcher({
     }
 
     const storedTheme = document.cookie.match(new RegExp(`(?:^|; )${LANDING_THEME_COOKIE}=([^;]*)`))?.[1];
-    if (storedTheme !== "system") return;
+    if (storedTheme === "system") {
+      setThemeMode("system");
+    }
+  }, [locale, router]);
 
+  useEffect(() => {
+    if (themeMode !== "system") return;
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const syncSystemTheme = () => applyTheme(resolveSystemTheme(), "system");
+    const syncSystemTheme = () => {
+      const nextTheme = resolveSystemTheme();
+      setLandingTheme(nextTheme);
+      document.querySelector<HTMLElement>(".clan-signal")?.setAttribute("data-cs-theme", nextTheme);
+    };
     syncSystemTheme();
     mediaQuery.addEventListener("change", syncSystemTheme);
     return () => mediaQuery.removeEventListener("change", syncSystemTheme);
-  }, [locale, router]);
+  }, [themeMode]);
 
   const switchLocale = (nextLocale: SupportedLocale, mode: LocaleMode) => {
     document.cookie = `${LOCALE_MODE_COOKIE}=${mode}; path=/; max-age=31536000; SameSite=Lax`;

--- a/components/landing/explorations/clan-signal/language-switcher.tsx
+++ b/components/landing/explorations/clan-signal/language-switcher.tsx
@@ -36,6 +36,7 @@ type LandingLanguageSwitcherProps = {
 };
 
 type LandingTheme = "day" | "sunset";
+type LandingThemeMode = LandingTheme | "system";
 
 export function LandingLanguageSwitcher({
   label,
@@ -91,7 +92,12 @@ export function LandingLanguageSwitcher({
     if (value === "sunset") setTheme("dark");
   };
 
-  const themeMode = theme === "light" ? "day" : theme === "dark" ? "sunset" : "system";
+  let themeMode: LandingThemeMode = "system";
+  if (theme === "light") {
+    themeMode = "day";
+  } else if (theme === "dark") {
+    themeMode = "sunset";
+  }
 
   const applyLocalePreference = (value: string) => {
     if (value === "system") {

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -22,9 +22,9 @@ export async function ClanSignalLegalShell({
   const t = await getTranslations("ClanSignal");
   const cookieStore = await cookies();
   const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
-  const landingTheme = storedLandingTheme === "sunset" || storedLandingTheme === "system"
+  const landingTheme = storedLandingTheme === "day" || storedLandingTheme === "sunset"
     ? storedLandingTheme
-    : "day";
+    : "system";
 
   return (
     <main className="clan-signal cs-legal-page" data-cs-theme={landingTheme}>

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -36,7 +36,10 @@ export async function ClanSignalLegalShell({
           <div className="cs-nav-actions">
             <LandingLanguageSwitcher
               label={t("language.label")}
+              languageLabel={t("language.label")}
               appearanceLabel={t("appearance.label")}
+              systemLanguageLabel={t("language.system")}
+              systemAppearanceLabel={t("appearance.system")}
               dayLabel={t("appearance.day")}
               sunsetLabel={t("appearance.sunset")}
               initialTheme={landingTheme}

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -21,7 +21,10 @@ export async function ClanSignalLegalShell({
 }>) {
   const t = await getTranslations("ClanSignal");
   const cookieStore = await cookies();
-  const landingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value === "sunset" ? "sunset" : "day";
+  const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
+  const landingTheme = storedLandingTheme === "sunset" || storedLandingTheme === "system"
+    ? storedLandingTheme
+    : "day";
 
   return (
     <main className="clan-signal cs-legal-page" data-cs-theme={landingTheme}>

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
@@ -7,6 +8,7 @@ import { LandingLanguageSwitcher } from "./language-switcher";
 import "../../../../app/explorations/clan-signal.css";
 
 const LANDING_THEME_COOKIE = "CK_LANDING_THEME";
+const ARROW_ICON = "/concepts/local/assets/icons/Icon_DC_ArrowRight.png";
 
 export async function ClanSignalLegalShell({
   title,
@@ -44,6 +46,10 @@ export async function ClanSignalLegalShell({
               sunsetLabel={t("appearance.sunset")}
               initialTheme={landingTheme}
             />
+            <a className="cs-button cs-button-small" href="https://invite.clashk.ing/" target="_blank" rel="noreferrer">
+              {t("actions.addToDiscord")}
+              <Image src={ARROW_ICON} alt="" width={12} height={17} className="cs-arrow" unoptimized />
+            </a>
           </div>
         </nav>
       </header>

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -37,7 +37,7 @@ export async function ClanSignalLegalShell({
           </div>
           <div className="cs-nav-actions">
             <LandingLanguageSwitcher
-              label={t("language.label")}
+              label={t("settings.label")}
               languageLabel={t("language.label")}
               appearanceLabel={t("appearance.label")}
               systemLanguageLabel={t("language.system")}

--- a/components/landing/explorations/clan-signal/legal-shell.tsx
+++ b/components/landing/explorations/clan-signal/legal-shell.tsx
@@ -1,13 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 import { ClanSignalWordmark } from "./brand";
 import { ClanSignalFooter } from "./footer";
 import { LandingLanguageSwitcher } from "./language-switcher";
 import "../../../../app/explorations/clan-signal.css";
 
-const LANDING_THEME_COOKIE = "CK_LANDING_THEME";
 const ARROW_ICON = "/concepts/local/assets/icons/Icon_DC_ArrowRight.png";
 
 export async function ClanSignalLegalShell({
@@ -20,14 +18,9 @@ export async function ClanSignalLegalShell({
   children: React.ReactNode;
 }>) {
   const t = await getTranslations("ClanSignal");
-  const cookieStore = await cookies();
-  const storedLandingTheme = cookieStore.get(LANDING_THEME_COOKIE)?.value;
-  const landingTheme = storedLandingTheme === "day" || storedLandingTheme === "sunset"
-    ? storedLandingTheme
-    : "system";
 
   return (
-    <main className="clan-signal cs-legal-page" data-cs-theme={landingTheme}>
+    <main className="clan-signal cs-legal-page" data-cs-theme="system">
       <header className="cs-nav-shell">
         <nav className="cs-nav" aria-label={t("navigation.ariaLabel")}>
           <Link href="/" aria-label={t("navigation.homeLabel")} className="cs-nav-brand">
@@ -47,7 +40,6 @@ export async function ClanSignalLegalShell({
               systemAppearanceLabel={t("appearance.system")}
               dayLabel={t("appearance.day")}
               sunsetLabel={t("appearance.sunset")}
-              initialTheme={landingTheme}
             />
             <a className="cs-button cs-button-small" href="https://invite.clashk.ing/" target="_blank" rel="noreferrer">
               {t("actions.addToDiscord")}

--- a/lib/locale-preference.test.ts
+++ b/lib/locale-preference.test.ts
@@ -42,6 +42,11 @@ describe("getLocaleModeFromCookie", () => {
     expect(getLocaleModeFromCookie("other=value")).toBe("browser");
   });
 
+  it("preserves a legacy NEXT_LOCALE preference as manual", () => {
+    expect(getLocaleModeFromCookie("NEXT_LOCALE=fr")).toBe("manual");
+    expect(getLocaleModeFromCookie("foo=bar; NEXT_LOCALE=nl")).toBe("manual");
+  });
+
   it("returns 'browser' when cookie ends with 'browser'", () => {
     expect(getLocaleModeFromCookie(`${LOCALE_MODE_COOKIE}=browser`)).toBe("browser");
   });

--- a/lib/locale-preference.test.ts
+++ b/lib/locale-preference.test.ts
@@ -37,9 +37,9 @@ describe("resolveBrowserLocale", () => {
 });
 
 describe("getLocaleModeFromCookie", () => {
-  it("returns 'manual' when cookie is absent", () => {
-    expect(getLocaleModeFromCookie("")).toBe("manual");
-    expect(getLocaleModeFromCookie("other=value")).toBe("manual");
+  it("returns 'browser' when cookie is absent", () => {
+    expect(getLocaleModeFromCookie("")).toBe("browser");
+    expect(getLocaleModeFromCookie("other=value")).toBe("browser");
   });
 
   it("returns 'browser' when cookie ends with 'browser'", () => {

--- a/lib/locale-preference.ts
+++ b/lib/locale-preference.ts
@@ -1,6 +1,7 @@
 import { routing } from "@/i18n/routing";
 
 export const LOCALE_MODE_COOKIE = "CK_LOCALE_MODE";
+const NEXT_LOCALE_COOKIE = "NEXT_LOCALE";
 
 export type LocaleMode = "manual" | "browser";
 export type SupportedLocale = "en" | "fr" | "nl";
@@ -39,6 +40,12 @@ export function getLocaleModeFromCookie(cookieString: string): LocaleMode {
     .find((part) => part.startsWith(`${LOCALE_MODE_COOKIE}=`));
 
   if (!cookie) {
+    const hasLegacyLocalePreference = cookieString
+      .split(";")
+      .map((part) => part.trim())
+      .some((part) => part.startsWith(`${NEXT_LOCALE_COOKIE}=`));
+
+    if (hasLegacyLocalePreference) return "manual";
     return "browser";
   }
 

--- a/lib/locale-preference.ts
+++ b/lib/locale-preference.ts
@@ -1,3 +1,5 @@
+import { routing } from "@/i18n/routing";
+
 export const LOCALE_MODE_COOKIE = "CK_LOCALE_MODE";
 
 export type LocaleMode = "manual" | "browser";
@@ -9,16 +11,20 @@ export const LANGUAGE_OPTIONS: ReadonlyArray<{ code: SupportedLocale; name: stri
   { code: "nl", name: "Nederlands", flagCode: "nl" },
 ];
 
+function isSupportedLocale(locale: string): locale is SupportedLocale {
+  return routing.locales.includes(locale as SupportedLocale);
+}
+
 export function resolveBrowserLocale(browserLanguages: readonly string[] = []): SupportedLocale {
   for (const rawLocale of browserLanguages) {
     const normalizedLocale = rawLocale.toLowerCase();
 
-    if (normalizedLocale === "en" || normalizedLocale === "fr" || normalizedLocale === "nl") {
+    if (isSupportedLocale(normalizedLocale)) {
       return normalizedLocale;
     }
 
     const baseLocale = normalizedLocale.split("-")[0];
-    if (baseLocale === "en" || baseLocale === "fr" || baseLocale === "nl") {
+    if (isSupportedLocale(baseLocale)) {
       return baseLocale;
     }
   }
@@ -33,9 +39,8 @@ export function getLocaleModeFromCookie(cookieString: string): LocaleMode {
     .find((part) => part.startsWith(`${LOCALE_MODE_COOKIE}=`));
 
   if (!cookie) {
-    return "manual";
+    return "browser";
   }
 
   return cookie.endsWith("browser") ? "browser" : "manual";
 }
-

--- a/messages/en.json
+++ b/messages/en.json
@@ -2920,8 +2920,8 @@
       "discordBot": "Discord Bot",
       "dashboard": "Dashboard"
     },
-    "language": { "label": "Language" },
-    "appearance": { "label": "Appearance", "day": "Day", "sunset": "Sunset" },
+    "language": { "label": "Language", "system": "Follow system language" },
+    "appearance": { "label": "Appearance", "system": "Follow system appearance", "day": "Day", "sunset": "Sunset" },
     "actions": {
       "addToDiscord": "Add to Discord",
       "addClashKing": "Add ClashKing",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2920,6 +2920,7 @@
       "discordBot": "Discord Bot",
       "dashboard": "Dashboard"
     },
+    "settings": { "label": "Settings" },
     "language": { "label": "Language", "system": "Follow system language" },
     "appearance": { "label": "Appearance", "system": "Follow system appearance", "day": "Day", "sunset": "Sunset" },
     "actions": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2943,6 +2943,7 @@
       "discordBot": "Bot Discord",
       "dashboard": "Tableau de bord"
     },
+    "settings": { "label": "Paramètres" },
     "language": { "label": "Langue", "system": "Suivre la langue du système" },
     "appearance": { "label": "Apparence", "system": "Suivre l’apparence du système", "day": "Jour", "sunset": "Coucher de soleil" },
     "actions": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2943,8 +2943,8 @@
       "discordBot": "Bot Discord",
       "dashboard": "Tableau de bord"
     },
-    "language": { "label": "Langue" },
-    "appearance": { "label": "Apparence", "day": "Jour", "sunset": "Coucher de soleil" },
+    "language": { "label": "Langue", "system": "Suivre la langue du système" },
+    "appearance": { "label": "Apparence", "system": "Suivre l’apparence du système", "day": "Jour", "sunset": "Coucher de soleil" },
     "actions": {
       "addToDiscord": "Ajouter à Discord",
       "addClashKing": "Ajouter ClashKing",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -2923,6 +2923,7 @@
       "discordBot": "Discord-bot",
       "dashboard": "Dashboard"
     },
+    "settings": { "label": "Instellingen" },
     "language": { "label": "Taal", "system": "Systeemtaal volgen" },
     "appearance": { "label": "Weergave", "system": "Systeemuiterlijk volgen", "day": "Dag", "sunset": "Zonsondergang" },
     "actions": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -2923,8 +2923,8 @@
       "discordBot": "Discord-bot",
       "dashboard": "Dashboard"
     },
-    "language": { "label": "Taal" },
-    "appearance": { "label": "Weergave", "day": "Dag", "sunset": "Zonsondergang" },
+    "language": { "label": "Taal", "system": "Systeemtaal volgen" },
+    "appearance": { "label": "Weergave", "system": "Systeemuiterlijk volgen", "day": "Dag", "sunset": "Zonsondergang" },
     "actions": {
       "addToDiscord": "Voeg toe aan Discord",
       "addClashKing": "Voeg ClashKing toe",


### PR DESCRIPTION
## Summary
- replace the Clan Signal language control with an accessible Settings menu containing Appearance and Language submenus
- default both preferences to follow the supported system/browser setting
- synchronize Clan Signal appearance with the dashboard: light maps to Day, dark maps to Sunset, and system follows the OS
- give the Privacy Policy and Terms of Service pages the same header and Add to Discord action as the landing page

## Why
The landing page previously kept its appearance preference separate from the dashboard and exposed no grouped settings control.

## Validation
- npm run lint -- --quiet